### PR TITLE
fix(session): 兼容 Windows Git Bash/MSYS/Cygwin/WSL 启动 dsh-tui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 
 ### Fixed
 
+## [0.6.1] - 2026-08-17
+
+> 经 PR [#3](https://github.com/baobaolaodie/dsh-tui-vscode/pull/3) 合并 / via PR #3
+
+### Added
+
+### Changed
+
+### Fixed
+
 - **修复 Windows 非 PowerShell 终端（Git Bash 等）启动失败**：npm 全局安装会在 Windows 上同时生成 `.cmd` 与无扩展名 bash shim；扩展原先把 `dsh-tui.cmd` 的 Windows 绝对路径直接发给 bash，反斜杠被吞成 `C:Users...: command not found`。现在按终端 shell 类型区分：Git Bash/MSYS/Cygwin/WSL 优先解析 npm 的 bash shim 并把路径转成 POSIX 形式（`/c/...`、`/cygdrive/c/...`、`/mnt/c/...`）后发送，PowerShell/CMD 保持原有 `.cmd/.exe` 解析。
 
 ## [0.6.0] - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- **修复 Windows 非 PowerShell 终端（Git Bash 等）启动失败**：npm 全局安装会在 Windows 上同时生成 `.cmd` 与无扩展名 bash shim；扩展原先把 `dsh-tui.cmd` 的 Windows 绝对路径直接发给 bash，反斜杠被吞成 `C:Users...: command not found`。现在按终端 shell 类型区分：Git Bash/MSYS/Cygwin/WSL 优先解析 npm 的 bash shim 并把路径转成 POSIX 形式（`/c/...`、`/cygdrive/c/...`、`/mnt/c/...`）后发送，PowerShell/CMD 保持原有 `.cmd/.exe` 解析。
+
 ## [0.6.0] - 2026-08-17
 
 > 经 PR [#1](https://github.com/baobaolaodie/dsh-tui-vscode/pull/1) 合并 / via PR #1

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -12,6 +12,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ### Fixed
 
+## [0.6.1] - 2026-08-17
+
+> via PR [#3](https://github.com/baobaolaodie/dsh-tui-vscode/pull/3)
+
+### Added
+
+### Changed
+
+### Fixed
+
 - **Fixed launching under non-PowerShell Windows terminals (Git Bash etc.)**: npm global installs create both a `.cmd` shim and an extensionless bash shim on Windows; the extension previously sent the Windows absolute path of `dsh-tui.cmd` directly to bash, which swallowed the backslashes and reported `C:Users...: command not found`. The launch path now respects the terminal shell: bash/MSYS/Cygwin/WSL prefer npm's bash shim and convert the path to POSIX form (`/c/...`, `/cygdrive/c/...`, `/mnt/c/...`) before sending; PowerShell/CMD keep the existing `.cmd/.exe` resolution.
 
 ## [0.6.0] - 2026-08-17

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -12,6 +12,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ### Fixed
 
+- **Fixed launching under non-PowerShell Windows terminals (Git Bash etc.)**: npm global installs create both a `.cmd` shim and an extensionless bash shim on Windows; the extension previously sent the Windows absolute path of `dsh-tui.cmd` directly to bash, which swallowed the backslashes and reported `C:Users...: command not found`. The launch path now respects the terminal shell: bash/MSYS/Cygwin/WSL prefer npm's bash shim and convert the path to POSIX form (`/c/...`, `/cygdrive/c/...`, `/mnt/c/...`) before sending; PowerShell/CMD keep the existing `.cmd/.exe` resolution.
+
 ## [0.6.0] - 2026-08-17
 
 > via PR [#1](https://github.com/baobaolaodie/dsh-tui-vscode/pull/1)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.6.0-4D6BFE?style=flat" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.6.1-4D6BFE?style=flat" alt="Version" />
   <img src="https://img.shields.io/badge/VS_Code-%5E1.90.0-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code" />
   <img src="https://img.shields.io/badge/TypeScript-5.6-3178C6?style=flat&logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=flat" alt="MIT" />

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-tui
 git clone https://github.com/baobaolaodie/dsh-tui-vscode.git
 cd dsh-tui-vscode
 npm install
-npm run package && code --install-extension dsh-tui-vscode-0.5.1.vsix --force
-# 或一步到位：npm run install:local
+npm run install:local
 ```
 
 ## 使用
@@ -130,7 +129,8 @@ dsh-tui-vscode/
 ├── media/icon.svg          # DeepSeek 鲸鱼图标（活动栏 / 终端标签）
 ├── media/icon.png          # Marketplace 图标
 ├── scripts/
-│   └── install-commit-hook.mjs  # 本地钩子安装脚本
+│   ├── install-commit-hook.mjs  # 本地钩子安装脚本
+│   └── install-local.mjs        # 安装本地打包的 vsix（从 package.json 动态取版本号）
 ├── .githooks/              # pre-commit / commit-msg（入库分发）
 ├── .github/
 │   ├── workflows/ci.yml    # 完整 CI（test 矩阵/e2e/quality/pr-policy/release-consistency/security-scan/docs-links）

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.6.0-4D6BFE?style=flat" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.6.1-4D6BFE?style=flat" alt="Version" />
   <img src="https://img.shields.io/badge/VS_Code-%5E1.90.0-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code" />
   <img src="https://img.shields.io/badge/TypeScript-5.6-3178C6?style=flat&logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=flat" alt="MIT" />

--- a/README_EN.md
+++ b/README_EN.md
@@ -61,8 +61,7 @@ Install from the **VS Code extension marketplace** (recommended): press `Ctrl+Sh
 git clone https://github.com/baobaolaodie/dsh-tui-vscode.git
 cd dsh-tui-vscode
 npm install
-npm run package && code --install-extension dsh-tui-vscode-0.5.1.vsix --force
-# or: npm run install:local
+npm run install:local
 ```
 
 ## Usage
@@ -130,7 +129,8 @@ dsh-tui-vscode/
 ├── media/icon.svg          # DeepSeek whale icon (activity bar / terminal tab)
 ├── media/icon.png          # Marketplace icon
 ├── scripts/
-│   └── install-commit-hook.mjs  # local hook installer
+│   ├── install-commit-hook.mjs  # local hook installer
+│   └── install-local.mjs        # installs the locally packaged vsix (version read from package.json)
 ├── .githooks/              # pre-commit / commit-msg (shipped in the repo)
 ├── .github/
 │   ├── workflows/ci.yml    # full CI (test matrix/e2e/quality/pr-policy/release-consistency/security-scan/docs-links)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dsh-tui-vscode",
   "displayName": "dsh-tui (VS Code)",
   "description": "Run dsh-TUI in a real VS Code integrated terminal — an experience almost identical to the official Claude Code extension: Beside placement, multiple concurrent sessions, sidebar session history, one-click start/resume. 让 dsh-TUI 跑在真实集成终端里，体验与 Claude Code 官方扩展几乎一致。",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "baobaolaodie",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "test": "npm run compile && node --test out/test/session.test.js out/test/sessions.test.js",
     "test:e2e": "npm run compile && tsc -p tsconfig.test.json && node out-test/test-suite/run-tests.js",
     "package": "npm run compile && vsce package",
-    "install:local": "npm run package && code --install-extension dsh-tui-vscode-0.5.1.vsix --force"
+    "install:local": "npm run package && node scripts/install-local.mjs"
   },
   "dependencies": {
     "@bokuweb/zstd-wasm": "^0.0.27"

--- a/scripts/install-local.mjs
+++ b/scripts/install-local.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// 本地安装打包产物：node scripts/install-local.mjs（由 `npm run install:local` 调用）。
+// 设计：vsce 默认产物名为 <name>-<version>.vsix，这里从 package.json 动态读取
+// name/version 拼接——版本升级时无需同步任何硬编码文件名（曾硬编码 0.5.1 导致
+// 版本升到 0.6.0 后 install:local 找不到旧文件而失败）。
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url))
+const pkg = JSON.parse(readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
+const vsix = `${pkg.name}-${pkg.version}.vsix`
+
+execSync(`code --install-extension ${vsix} --force`, { cwd: ROOT, stdio: 'inherit' })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import {
   readWorkspaceMeta,
   listSessions,
 } from './sessions'
-import { buildLaunchEnv, resolveLaunchCommand, quoteLaunchPath } from './session'
+import { buildLaunchEnv, resolveLaunchCommand, detectShellKind, formatLaunchPath } from './session'
 
 const TERMINAL_NAME = 'DeepSeek'
 
@@ -141,11 +141,13 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
   function runCommand(resume: boolean, resumeSession?: string): void {
     const cfg = readSettings()
     const isWindows = process.platform === 'win32'
+    const shellKind = detectShellKind(vscode.env.shell)
     const command = cfg.command.trim() || 'dsh-tui'
     // Resolve against the HOST PATH: the terminal shell's PATH may differ
-    // (login shells rebuild it) — verified on Linux CI.
-    const resolved = resolveLaunchCommand(command, isWindows)
-    const parts = resolved ? [quoteLaunchPath(resolved, isWindows)] : [command]
+    // (login shells rebuild it) — verified on Linux CI. The shell kind also
+    // tells us whether a Windows path must be converted for Git Bash/WSL.
+    const resolved = resolveLaunchCommand(command, isWindows, shellKind)
+    const parts = [formatLaunchPath(resolved ?? command, shellKind, isWindows)]
     for (const arg of cfg.extraArgs) parts.push(arg)
 
     const existing = findTerminal()

--- a/src/session.ts
+++ b/src/session.ts
@@ -9,24 +9,112 @@ import { existsSync, statSync, accessSync, constants } from 'node:fs'
 import { delimiter, join } from 'node:path'
 
 /**
+ * Terminal shell families. `bash` covers MSYS2/Git Bash and other POSIX-like
+ * shells; `cygwin` and `wsl` are separate because their drive mappings differ
+ * (`/cygdrive/<drive>` and `/mnt/<drive>` respectively).
+ */
+export type ShellKind = 'powershell' | 'cmd' | 'bash' | 'cygwin' | 'wsl' | 'unknown'
+
+/**
+ * Detect the terminal shell family from VS Code's `env.shell` path or from a
+ * `TerminalState.shell` value. The latter uses normalized names like 'bash',
+ * 'gitbash', 'pwsh', 'cmd', and 'wsl', while the former is an absolute path.
+ */
+export function detectShellKind(shell: string | undefined): ShellKind {
+  const value = (shell ?? '').trim().toLowerCase().replace(/\\/g, '/')
+  const base = value.slice(value.lastIndexOf('/') + 1)
+  if (!base) return 'unknown'
+  if (base.includes('powershell') || base.includes('pwsh')) return 'powershell'
+  if (base === 'cmd' || base.endsWith('.cmd') || base.endsWith('cmd.exe')) return 'cmd'
+  if (base.includes('wsl')) return 'wsl'
+  // C:\Windows\System32\bash.exe is the WSL bash launcher, not Git Bash.
+  if (base === 'bash.exe' && value.includes('/windows/system32/')) return 'wsl'
+  if (value.includes('cygwin')) return 'cygwin'
+  if (
+    base.includes('bash') ||
+    base.includes('zsh') ||
+    base.includes('fish') ||
+    base.includes('ksh') ||
+    base.includes('csh') ||
+    base.includes('xonsh') ||
+    base === 'sh' ||
+    base.startsWith('sh.') ||
+    base.includes('nu')
+  ) {
+    return 'bash'
+  }
+  return 'unknown'
+}
+
+const isBashLike = (kind: ShellKind): boolean =>
+  kind === 'bash' || kind === 'cygwin' || kind === 'wsl'
+
+/**
+ * Convert a Windows absolute path (e.g. `C:\Users\...`) into a POSIX-style
+ * path that a bash-like shell can execute. Git Bash/MSYS2 mount drive letters
+ * at `/<drive>`, Cygwin mounts them at `/cygdrive/<drive>`, and WSL mounts
+ * them at `/mnt/<drive>`.
+ */
+export function windowsPathToPosix(path: string, shellKind: ShellKind): string {
+  const forward = path.replace(/\\/g, '/')
+  const drive = /^([A-Za-z]):\/(.*)$/.exec(forward)
+  if (drive) {
+    const rest = drive[2]
+    if (shellKind === 'wsl') return `/mnt/${drive[1].toLowerCase()}/${rest}`
+    if (shellKind === 'cygwin') return `/cygdrive/${drive[1].toLowerCase()}/${rest}`
+    return `/${drive[1].toLowerCase()}/${rest}`
+  }
+  if (forward.startsWith('//')) {
+    // \\server\share → //server/share; Git Bash/MSYS2 can address it as /server/share.
+    return shellKind === 'wsl' ? forward : `/${forward.slice(2)}`
+  }
+  return forward
+}
+
+/**
  * Resolve a bare command name to an absolute executable using the EXTENSION
  * HOST's PATH. The terminal shell's PATH is not trustworthy (login shells
  * rebuild it from profile scripts — verified on CI: an injected PATH dir
  * vanished from the shell), so the launch command is resolved here and sent
  * as an absolute path.
  *
+ * On Windows, npm global packages install three shims for the same binary:
+ * `.cmd` for cmd.exe, `.ps1` for PowerShell, and an extensionless shell
+ * script for Cygwin/MSYS2. When the terminal is bash-like we therefore prefer
+ * the extensionless shim; otherwise the existing `.cmd`/`.bat`/`.exe` search
+ * applies.
+ *
  * @returns The absolute path, or undefined when the command is already
  * path-like or cannot be resolved (the bare name is then sent as-is).
  */
-export function resolveLaunchCommand(command: string, isWindows: boolean): string | undefined {
+export function resolveLaunchCommand(
+  command: string,
+  isWindows: boolean,
+  shellKind?: ShellKind,
+): string | undefined {
   if (command.includes('/') || (isWindows && command.includes('\\'))) {
     return undefined // already path-like — let the shell handle it
   }
+  const kind = shellKind ?? (isWindows ? 'powershell' : 'bash')
   const pathEnv = process.env.PATH ?? ''
-  for (const dir of pathEnv.split(delimiter)) {
-    if (!dir) continue
+  const dirs = pathEnv.split(delimiter).filter(Boolean)
+
+  if (isWindows && isBashLike(kind)) {
+    // Prefer npm's extensionless bash shim over the .cmd/.bat/.exe shims.
+    for (const dir of dirs) {
+      const candidate = join(dir, command)
+      try {
+        if (statSync(candidate).isFile()) return candidate
+      } catch {
+        // not a usable candidate — keep looking
+      }
+    }
+  }
+
+  for (const dir of dirs) {
     if (isWindows) {
-      for (const ext of ['.cmd', '.bat', '.exe']) {
+      const exts = isBashLike(kind) ? ['.exe', '.cmd', '.bat'] : ['.cmd', '.bat', '.exe']
+      for (const ext of exts) {
         const candidate = join(dir, command + ext)
         if (existsSync(candidate)) return candidate
       }
@@ -49,6 +137,29 @@ export function resolveLaunchCommand(command: string, isWindows: boolean): strin
 export function quoteLaunchPath(path: string, isWindows: boolean): string {
   if (!path.includes(' ')) return path
   return isWindows ? `& '${path}'` : `'${path}'`
+}
+
+/**
+ * Format a resolved launch path for the actual terminal shell. On Windows
+ * bash-like shells the Windows path must be converted to POSIX form before it
+ * reaches the shell; otherwise `C:\Users\...` is mangled by bash into
+ * `C:Users...` and reported as "command not found".
+ */
+export function formatLaunchPath(path: string, shellKind: ShellKind, isWindows: boolean): string {
+  const display = isWindows && isBashLike(shellKind) ? windowsPathToPosix(path, shellKind) : path
+  if (!display.includes(' ')) return display
+  switch (shellKind) {
+    case 'cmd':
+      return `"${display}"`
+    case 'powershell':
+      return `& '${display}'`
+    case 'bash':
+    case 'cygwin':
+    case 'wsl':
+      return `'${display}'`
+    default:
+      return isWindows ? `& '${display}'` : `'${display}'`
+  }
 }
 export interface LaunchEnvInput {
   /** Process environment to respect (e.g. process.env). */

--- a/src/test/session.test.ts
+++ b/src/test/session.test.ts
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict'
 import { writeFileSync, mkdtempSync, rmSync, chmodSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { resolveLaunchCommand, quoteLaunchPath } from '../session.js'
+import {
+  resolveLaunchCommand,
+  quoteLaunchPath,
+  detectShellKind,
+  formatLaunchPath,
+} from '../session.js'
 
 test('resolveLaunchCommand finds .cmd/.bat/.exe on Windows PATH', () => {
   const dir = mkdtempSync(join(tmpdir(), 'dsh-launch-win-'))
@@ -24,6 +29,68 @@ test('resolveLaunchCommand finds .cmd/.bat/.exe on Windows PATH', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
+})
+
+test('resolveLaunchCommand prefers npm bash shim for bash-like Windows shells', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-launch-bash-win-'))
+  try {
+    writeFileSync(join(dir, 'dsh-tui'), '#!/bin/sh\n')
+    writeFileSync(join(dir, 'dsh-tui.cmd'), '@echo off\r\n')
+    writeFileSync(join(dir, 'dsh-tui.ps1'), '')
+    const original = process.env.PATH
+    process.env.PATH = dir
+    try {
+      assert.equal(resolveLaunchCommand('dsh-tui', true), join(dir, 'dsh-tui.cmd'))
+      assert.equal(resolveLaunchCommand('dsh-tui', true, 'bash'), join(dir, 'dsh-tui'))
+      assert.equal(resolveLaunchCommand('dsh-tui', true, 'cygwin'), join(dir, 'dsh-tui'))
+      assert.equal(resolveLaunchCommand('dsh-tui', true, 'wsl'), join(dir, 'dsh-tui'))
+      assert.equal(resolveLaunchCommand('dsh-tui', true, 'powershell'), join(dir, 'dsh-tui.cmd'))
+    } finally {
+      process.env.PATH = original
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('detectShellKind recognizes PowerShell, cmd, Git Bash, and WSL', () => {
+  assert.equal(detectShellKind('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'), 'powershell')
+  assert.equal(detectShellKind('pwsh'), 'powershell')
+  assert.equal(detectShellKind('C:\\Windows\\System32\\cmd.exe'), 'cmd')
+  assert.equal(detectShellKind('C:\\Program Files\\Git\\bin\\bash.exe'), 'bash')
+  assert.equal(detectShellKind('gitbash'), 'bash')
+  assert.equal(detectShellKind('C:\\cygwin64\\bin\\bash.exe'), 'cygwin')
+  assert.equal(detectShellKind('C:\\Windows\\System32\\wsl.exe'), 'wsl')
+  assert.equal(detectShellKind('C:\\Windows\\System32\\bash.exe'), 'wsl')
+  assert.equal(detectShellKind(undefined), 'unknown')
+})
+
+test('formatLaunchPath converts Windows paths for bash-like shells', () => {
+  assert.equal(
+    formatLaunchPath('C:\\Users\\admin\\AppData\\Roaming\\npm\\dsh-tui', 'bash', true),
+    '/c/Users/admin/AppData/Roaming/npm/dsh-tui',
+  )
+  assert.equal(
+    formatLaunchPath('C:\\Users\\admin\\AppData\\Roaming\\npm\\dsh-tui', 'cygwin', true),
+    '/cygdrive/c/Users/admin/AppData/Roaming/npm/dsh-tui',
+  )
+  assert.equal(
+    formatLaunchPath('C:\\Users\\admin\\AppData\\Roaming\\npm\\dsh-tui', 'wsl', true),
+    '/mnt/c/Users/admin/AppData/Roaming/npm/dsh-tui',
+  )
+  assert.equal(
+    formatLaunchPath('C:\\Program Files\\dsh-tui', 'bash', true),
+    "'/c/Program Files/dsh-tui'",
+  )
+  assert.equal(
+    formatLaunchPath('C:\\Program Files\\dsh-tui.cmd', 'powershell', true),
+    "& 'C:\\Program Files\\dsh-tui.cmd'",
+  )
+  assert.equal(
+    formatLaunchPath('C:\\Program Files\\dsh-tui.cmd', 'cmd', true),
+    '"C:\\Program Files\\dsh-tui.cmd"',
+  )
+  assert.equal(formatLaunchPath('/usr/local/bin/dsh-tui', 'bash', false), '/usr/local/bin/dsh-tui')
 })
 
 test('resolveLaunchCommand finds executable files on POSIX PATH', () => {


### PR DESCRIPTION
## 摘要 / Summary

修复 Windows 下使用 Git Bash/MSYS/Cygwin/WSL 作为 VS Code 默认终端时，dsh-tui 启动报 `C:Users... command not found` 的问题。

- 根因：旧代码将 npm 生成的 Windows `.cmd` 路径原样发送给 bash，反斜杠被吞。
- 做法：识别终端 shell 类型，bash 类终端优先解析 npm 无扩展名 bash shim，并把路径转为 POSIX 形式。
- 影响：PowerShell/CMD 行为不变，bash 类终端可正常启动。

## 改动范围（勾选）/ Scope of Changes (check)

- [x] 核心逻辑（终端 / 会话）/ Core logic (terminal / session)
- [ ] 会话历史（侧边栏）/ Session history (sidebar)
- [x] 文档（README / docs / CHANGELOG / CONTRIBUTING）/ Docs
- [ ] 其他 / Other:

## 验证（勾选已执行）/ Verification (check executed)

- [x] 单元测试 / Unit tests（命令 + 结果 / command + result）:
- [ ] 手动验证 / Manual verification（描述场景 / describe the scenario）:
- [x] 文档改动：中英双语同步 / Doc changes: EN and ZH mirrored
- [x] 关键验证输出已粘贴至验证段下方 / Key verification output pasted below
- [x] 如有未运行的验证项（说明原因）/ Not run if any (explain):

### 单元测试输出

`npm run typecheck` 通过；`npm test` 通过（34/34）。

```text
✔ 34 tests passed
```

未运行真机 Git Bash 手动验证（当前环境无 Git Bash），由单元测试覆盖路径转换逻辑。

## 自查（勾选）/ Self-check (check)

- [x] 行为变化已记入 CHANGELOG(Unreleased)/ Behavior changes recorded in CHANGELOG (Unreleased)
- [x] 版本号与实现一致 / Version number matches the implementation
- [x] 无无关文件或本地伪影 / No unrelated files or local artifacts

## 基于版本 / Based on

最新默认分支 `main`（beb3e844）。

## 关联（可选）/ Related (optional)

Fixes #2

## 审查注意点 / Review Notes

- 路径转换覆盖 Git Bash/MSYS2 `/c/...`、Cygwin `/cygdrive/c/...`、WSL `/mnt/c/...`。
- 请重点检查 `src/session.ts` 中 `detectShellKind` 与 `formatLaunchPath` 的边界情况。