### PR TITLE
chore(build): 同步 package-lock 并排除 CLAUDE.md 出 VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,6 +17,7 @@ package-lock.json
 *.vsix
 *.log
 .gh-log/
+CLAUDE.md
 
 .githooks/
 scripts/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-tui-vscode",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-tui-vscode",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@bokuweb/zstd-wasm": "^0.0.27"


### PR DESCRIPTION
## 摘要 / Summary

同步 `package-lock.json` 根版本到 0.6.1，并在 `.vscodeignore` 中排除 `CLAUDE.md`，避免内部文档进入 VSIX 包。

## 改动范围（勾选）/ Scope of Changes (check)

- [ ] 核心逻辑（终端 / 会话）/ Core logic (terminal / session)
- [ ] 会话历史（侧边栏）/ Session history (sidebar)
- [ ] 文档（README / docs / CHANGELOG / CONTRIBUTING）/ Docs
- [x] 其他 / Other: 构建配置（.vscodeignore / package-lock）

## 验证（勾选已执行）/ Verification (check executed)

- [x] 单元测试 / Unit tests（命令 + 结果 / command + result）:
- [ ] 手动验证 / Manual verification（描述场景 / describe the scenario）:
- [ ] 文档改动：中英双语同步 / Doc changes: EN and ZH mirrored
- [x] 关键验证输出已粘贴至验证段下方 / Key verification output pasted below
- [ ] 如有未运行的验证项（说明原因）/ Not run if any (explain):

### 验证输出

`npm test` 通过（34/34），pre-commit 钩子通过。

## 自查（勾选）/ Self-check (check)

- [ ] 行为变化已记入 CHANGELOG(Unreleased)/ Behavior changes recorded in CHANGELOG (Unreleased)
- [x] 版本号与实现一致 / Version number matches the implementation
- [x] 无无关文件或本地伪影 / No unrelated files or local artifacts

## 基于版本 / Based on

main @ c1b6d1d

## 关联（可选）/ Related (optional)

无

## 审查注意点 / Review Notes

- `.vscodeignore` 增加 `CLAUDE.md`
- `package-lock.json` 根版本从 0.5.1 同步到 0.6.1