### PR TITLE
feat(at-mention): experimental auto @-mention on selection + keybinding docs

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,6 +18,8 @@ package-lock.json
 *.log
 .gh-log/
 CLAUDE.md
+.scratch/
+.tmp-audit/
 
 .githooks/
 scripts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.3] - 2026-08-19
+
+> 经 PR [#10](https://github.com/baobaolaodie/dsh-tui-vscode/pull/10) 合并 / via PR #10
+
+### Added
+
 - **选区变化自动引用（experimental，默认关）**：新增配置 `dsh-tui-vscode.autoInsertMention`（默认 `false`），开启后在编辑器选中代码时自动以 `@绝对路径 L起-止` 形式插入运行中的 dsh-tui 输入框（300ms 防抖、仅当存在运行中会话、对同一选区去重、无会话静默忽略）。官方 Claude Code 经其原生 `selection_changed` 通道实现该能力，本项为其 dsh-tui 降级近似；与 dsh-TUI 上游 issue #359（相对路径 + #L 行区间）解耦，待上游落地后升级。
 - **快捷键冲突说明**：README 增加默认键 `Ctrl+Alt+K`（macOS `Cmd+Alt+K`）与 opencode 等扩展撞键时的重绑方法（「键盘快捷方式」`Ctrl+K Ctrl+S`），右键/命令面板入口不受影响。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- **选区变化自动引用（experimental，默认关）**：新增配置 `dsh-tui-vscode.autoInsertMention`（默认 `false`），开启后在编辑器选中代码时自动以 `@绝对路径 L起-止` 形式插入运行中的 dsh-tui 输入框（300ms 防抖、仅当存在运行中会话、对同一选区去重、无会话静默忽略）。官方 Claude Code 经其原生 `selection_changed` 通道实现该能力，本项为其 dsh-tui 降级近似；与 dsh-TUI 上游 issue #359（相对路径 + #L 行区间）解耦，待上游落地后升级。
+- **快捷键冲突说明**：README 增加默认键 `Ctrl+Alt+K`（macOS `Cmd+Alt+K`）与 opencode 等扩展撞键时的重绑方法（「键盘快捷方式」`Ctrl+K Ctrl+S`），右键/命令面板入口不受影响。
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -8,6 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ### Added
 
+- **Experimental auto @-mention on selection (off by default)**: new setting `dsh-tui-vscode.autoInsertMention` (default `false`). When enabled, selecting code in the editor auto-inserts `@absolute/path Lstart-end` into the running dsh-tui input box (300 ms debounce, only when a session is running, deduped per selection, silently ignored otherwise). The official Claude Code extension implements this via its native `selection_changed` channel; this is the dsh-tui degraded approximation, decoupled from upstream dsh-TUI issue #359 (relative paths + #L ranges) and upgraded once the upstream patch lands.
+- **Keybinding-conflict note**: README now documents how to rebind the default `Ctrl+Alt+K` (macOS `Cmd+Alt+K`) when it collides with extensions like opencode ("Keyboard Shortcuts" `Ctrl+K Ctrl+S`); context-menu / command-palette entries are unaffected.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.3] - 2026-08-19
+
+> via PR [#10](https://github.com/baobaolaodie/dsh-tui-vscode/pull/10) / 经 PR #10 合并
+
+### Added
+
 - **Experimental auto @-mention on selection (off by default)**: new setting `dsh-tui-vscode.autoInsertMention` (default `false`). When enabled, selecting code in the editor auto-inserts `@absolute/path Lstart-end` into the running dsh-tui input box (300 ms debounce, only when a session is running, deduped per selection, silently ignored otherwise). The official Claude Code extension implements this via its native `selection_changed` channel; this is the dsh-tui degraded approximation, decoupled from upstream dsh-TUI issue #359 (relative paths + #L ranges) and upgraded once the upstream patch lands.
 - **Keybinding-conflict note**: README now documents how to rebind the default `Ctrl+Alt+K` (macOS `Cmd+Alt+K`) when it collides with extensions like opencode ("Keyboard Shortcuts" `Ctrl+K Ctrl+S`); context-menu / command-palette entries are unaffected.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.6.2-4D6BFE?style=flat" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.6.3-4D6BFE?style=flat" alt="Version" />
   <img src="https://img.shields.io/badge/VS_Code-%5E1.90.0-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code" />
   <img src="https://img.shields.io/badge/TypeScript-5.6-3178C6?style=flat&logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=flat" alt="MIT" />

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm run install:local
 - **恢复指定会话**：侧边栏「会话历史」展开项目 → 点击会话条目——新终端携带 `DSH_TUI_RESUME_SESSION=<id>` 环境变量启动该会话。
 - **终止**：关闭终端标签（只结束该会话），或在 TUI 内双击 `Ctrl+C`；命令 `dsh-tui: Terminate session / 终止会话` 向最近终端发送 Ctrl+C。
 - **引用选中代码**：编辑器聚焦时按 `Ctrl+Alt+K`（macOS `Cmd+Alt+K`），或命令面板/编辑器右键「插入 @文件引用」——把当前文件或选中代码以 `@绝对路径 L起-止` 形式插入运行中的 dsh-tui 输入框（用正斜杠绝对路径,与 dsh-tui 会话工作目录无关;未选中则仅为 `@绝对路径` 引用整个文件。`@` 引用在提交时自动附加整个文件内容;行区间 `L起-止` 是空格分隔的纯文本提示——dsh-tui 不支持 `#L` 行区间语法）。无运行会话时回退为复制到剪贴板。行为以 Claude Code 官方 `insertAtMention` 为基准并做了 dsh-tui 适配。
+  - **快捷键冲突**：默认键 `Ctrl+Alt+K`（macOS `Cmd+Alt+K`）可能与 opencode 等扩展撞键（官方终端模式同样默认此键）。若无效或冲突，在「键盘快捷方式」（`Ctrl+K Ctrl+S`）搜索 `dsh_tui` 重绑为你习惯的键位即可；右键/命令面板入口不受影响。
 
 ## 架构
 
@@ -114,6 +115,7 @@ flowchart LR
 | `dsh-tui-vscode.injectEditor` | `true` | 未设 `$VISUAL`/`$EDITOR` 时导出 `$VISUAL` |
 | `dsh-tui-vscode.editorCommand` | `code -w` | 导出为 `$VISUAL` 的命令 |
 | `dsh-tui-vscode.dshHome` | `""` | 覆盖会话的 `$DSH_HOME`（空 = 继承） |
+| `dsh-tui-vscode.autoInsertMention` `*(experimental)*` | `false` | 选区变化时自动把选中代码以 `@绝对路径 L起-止` 插入运行中的 dsh-tui 输入框（300ms 防抖；仅当有运行中的会话时生效；默认关闭避免抢占/刷屏）。官方经原生 `selection_changed` 通道实现，本项为其 dsh-tui 降级近似，待上游补丁后升级 |
 
 ## 目录结构
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -71,6 +71,7 @@ npm run install:local
 - **Resume a specific session**: in the sidebar session history, expand a project and click a session — a new terminal boots it with `DSH_TUI_RESUME_SESSION=<id>` in its environment.
 - **Stop**: close the terminal tab (ends only that session), or double `Ctrl+C` inside the TUI; `dsh-tui: Terminate session / 终止会话` sends Ctrl+C to the most recent terminal.
 - **Reference selected code**: with editor focus, press `Ctrl+Alt+K` (macOS `Cmd+Alt+K`), or use the Command Palette / editor context menu "Insert @-mention" — it inserts the current file or selection as `@absolute/path Lstart-end` into the running dsh-tui input box (forward-slash absolute path, independent of the dsh-tui session cwd; `@absolute/path` alone references the whole file when nothing is selected. The `@` mention attaches the whole file's content on submit; the `Lstart-end` range is a space-separated plain-text hint — dsh-tui does not support `#L` line-range syntax). With no running session it falls back to copying to the clipboard. Based on the official Claude Code extension's `insertAtMention` and adapted for dsh-tui.
+  - **Keybinding conflicts**: the default `Ctrl+Alt+K` (macOS `Cmd+Alt+K`) may collide with extensions like opencode (the official terminal mode uses the same default). If it does not work or conflicts, open "Keyboard Shortcuts" (`Ctrl+K Ctrl+S`), search `dsh_tui`, and rebind it to your preferred keys; the context-menu / command-palette entries are unaffected.
 
 ## Architecture
 
@@ -114,6 +115,7 @@ Key points:
 | `dsh-tui-vscode.injectEditor` | `true` | Export `$VISUAL` when unset |
 | `dsh-tui-vscode.editorCommand` | `code -w` | Value exported as `$VISUAL` |
 | `dsh-tui-vscode.dshHome` | `""` | `$DSH_HOME` override (empty = inherit) |
+| `dsh-tui-vscode.autoInsertMention` `*(experimental)*` | `false` | On selection change, auto-insert the selected code as `@absolute/path Lstart-end` into the running dsh-tui input box (300 ms debounce; only when a session is running; disabled by default to avoid hijacking/spam). The official extension implements this via its native `selection_changed` channel; this is the dsh-tui degraded approximation, upgraded once the upstream patch lands |
 
 ## Directory Structure
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.6.2-4D6BFE?style=flat" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.6.3-4D6BFE?style=flat" alt="Version" />
   <img src="https://img.shields.io/badge/VS_Code-%5E1.90.0-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code" />
   <img src="https://img.shields.io/badge/TypeScript-5.6-3178C6?style=flat&logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=flat" alt="MIT" />

--- a/docs/at-mention-design.md
+++ b/docs/at-mention-design.md
@@ -63,6 +63,35 @@ const absolute = isAbsolute(mention.path) ? mention.path : join(cwd, mention.pat
 
 差距源于 dsh-tui 的架构(会话 cwd 中心 + 无 IPC 选区上下文),而非扩展能力不足。
 
+## 4.1 选区自动引用:官方真实机制(webview AND 终端模式)
+
+调查(官方 VSIX v2.1.235 解包)确认:**官方「编辑器选区自动出现在会话引用」不止 webview,终端模式同样有**。
+两者共用同一通道,与面板模式无关:
+
+1. 扩展 `onDidChangeTextEditorSelection` → 与上次选区 diff → **300ms 防抖**;
+2. 经扩展内部 WebSocket server(写 `~/.claude/ide/<port>.lock`,含 `transport:"ws"` + authToken,
+   CLI 侧自动发现)发送 JSON-RPC `selection_changed`(params: `{text, filePath, selection{start,end,isEmpty}}`);
+3. CLI(`claude`)消费后,把选区打包为 `<ide_selection>The user selected lines X-Y from PATH: TEXT</ide_selection>`
+   上下文标记,输入面显示引用标识(未选中为 `<ide_opened_file>`);
+4. 手动兜底(两种模式都有):`insertAtMention`(webview, alt+k)/ `insertAtMentioned`
+   (terminal, ctrl+alt+K)插入 `@相对路径#L起-止`。
+
+**结论**:官方终端模式的「自动选区引用」依赖 **CLI 内建协议**——扩展只做选区采集 + WS 通道,消费与显示全在 CLI。
+dsh-tui(whale,独立 cordis TUI)**不消费** `~/.claude/ide` / `selection_changed`,扩展又只有 `terminal.sendText`
+一条通道,故只能**降级近似**(见下节)。
+
+## 4.2 降级近似(本仓库已实现,experimental)
+
+`dsh-tui-vscode.autoInsertMention`(默认 **false**,experimental):开启后监听选区变化 →
+300ms 防抖 → 自动把 `@绝对路径 L起-止` `sendText` 键入**运行中的** dsh-tui 输入框。
+
+- 与官方差异:官方更新的是「上下文标记,不进输入框文字」;本实现是**实质性往输入框敲字**,
+  故默认关闭、仅当存在运行中会话、对同一选区去重,避免抢占/刷屏。
+- 无运行中会话时**静默忽略**(不复制、不提示),避免打扰。
+- 文件 scheme 外的编辑器(输出/终端等非文件)不触发。
+- 与上游补丁 #359 **解耦**:本次扩展侧可独立交付;`#L` 行区间/相对路径落在 dsh-TUI 上游
+  (issue #359),落地后本文档 §4 差距表与 §5 计划再将实现切回「相对路径 + #L 行区间」。
+
 ## 5. 未来计划:给 dsh-TUI 打补丁,对齐官方设计
 
 目标:让 `@相对路径` 与行区间在 dsh-tui 中原生可用,扩展回归「相对路径 + 行区间」,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dsh-tui-vscode",
   "displayName": "dsh-tui (VS Code)",
   "description": "Run dsh-TUI in a real VS Code integrated terminal — an experience almost identical to the official Claude Code extension: Beside placement, multiple concurrent sessions, sidebar session history, one-click start/resume. 让 dsh-TUI 跑在真实集成终端里，体验与 Claude Code 官方扩展几乎一致。",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "baobaolaodie",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -207,6 +207,11 @@
           "type": "string",
           "default": "",
           "description": "Optional $DSH_HOME override for the dsh-tui session ('' keeps the value inherited from the VS Code process)."
+        },
+        "dsh-tui-vscode.autoInsertMention": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "**Experimental** 选区变化时自动把选中代码以 `@绝对值路径 L起-止` 形式插入运行中的 dsh-tui 输入框（300ms 防抖，仅当存在运行中的 dsh-tui 会话时生效；默认关闭以避免抢占/刷屏）。官方 Claude Code 通过其原生 `selection_changed` 通道实现该能力，本项为其 dsh-tui 降级近似。"
         }
       }
     }
@@ -214,7 +219,7 @@
   "scripts": {
     "compile": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run compile && node --test out/test/session.test.js out/test/sessions.test.js out/test/at-mention.test.js",
+    "test": "npm run compile && node --test out/test/session.test.js out/test/sessions.test.js out/test/at-mention.test.js out/test/auto-mention.test.js",
     "test:e2e": "npm run compile && tsc -p tsconfig.test.json && node out-test/test-suite/run-tests.js",
     "package": "npm run compile && vsce package",
     "install:local": "npm run package && node scripts/install-local.mjs"

--- a/src/auto-mention.ts
+++ b/src/auto-mention.ts
@@ -1,0 +1,69 @@
+/**
+ * 选区变化自动引用(experimental)的纯函数决策层。
+ *
+ * 背景:Claude Code 官方「编辑器选区自动出现在会话引用」在 webview 与终端模式
+ * 都走 `~/.claude/ide` WebSocket(`selection_changed`)通道,由 CLI 消费后显示。
+ * dsh-tui 是独立 TUI,不消费该通道,`dsh-tui-vscode` 又只有 `terminal.sendText`
+ * 一条输入通道,因此只能做「降级近似」:监听选区变化 → 防抖后把
+ * `@绝对路径 L起-止` 自动键入运行中的 dsh-tui 输入框。
+ *
+ * 因为这是实打实地往终端输入框敲字(不是官方那种"更新上下文标记"),
+ * 默认**关闭**,需用户在设置里显式开启;本模块只做决策(是否插 / 插什么),
+ * 计时与实际 `sendText` 由 extension.ts 接线负责——决策保持纯函数,便于全量单测。
+ */
+
+import { buildAtMention, normalizeMentionPath } from './at-mention'
+
+/** 一次编辑器选区事件的快照(0-based 行号,VS Code 语义)。 */
+export interface SelectionSnapshot {
+  /** 文件路径(尚未归一化,保持 as-is;决策时会用 normalizeMentionPath)。 */
+  path: string
+  /** 选区起始行(0-based)。 */
+  startLine: number
+  /** 选区结束行(0-based)。 */
+  endLine: number
+}
+
+export interface AutoMentionGates {
+  /** dsh-tui-vscode.autoInsertMention(experimental)是否开启。 */
+  enabled: boolean
+  /** 编辑器当前是否有非空选区。 */
+  hasSelection: boolean
+  /** 是否存在运行中的 DeepSeek 终端(dsh-tui 会话)。 */
+  hasTerminal: boolean
+  /** 本次选区快照。 */
+  snapshot: SelectionSnapshot
+  /** 上一次真正注入过的引用原文(用于去重)。 */
+  lastInserted: string | undefined
+}
+
+export type AutoInsertOutcome =
+  | { action: 'skip'; reason: 'disabled' | 'no-selection' | 'no-terminal' | 'duplicate' }
+  | { action: 'insert'; mention: string }
+
+/**
+ * 决策:这次选区事件是否应触发一次自动引用注入。
+ *
+ * 门控顺序:开关 → 有选区 → 有运行中会话 → 与上次注入去重。
+ * 只要满足任一门控就返回 skip;否则返回 insert + 注入原文。
+ * 防抖窗口不在本函数处理(由调用方在两次 insert 之间用 setTimeout 收敛)。
+ */
+export function decideAutoInsert(gates: AutoMentionGates): AutoInsertOutcome {
+  if (!gates.enabled) return { action: 'skip', reason: 'disabled' }
+  if (!gates.hasSelection) return { action: 'skip', reason: 'no-selection' }
+  if (!gates.hasTerminal) return { action: 'skip', reason: 'no-terminal' }
+  const mention = buildMentionForSnapshot(gates.snapshot)
+  if (gates.lastInserted !== undefined && gates.lastInserted === mention) {
+    return { action: 'skip', reason: 'duplicate' }
+  }
+  return { action: 'insert', mention }
+}
+
+/** 由选区快照生成要键入的引用原文(归一化路径 + `@绝对路径 L起-止`)。 */
+export function buildMentionForSnapshot(snapshot: SelectionSnapshot): string {
+  return buildAtMention(normalizeMentionPath(snapshot.path), {
+    isEmpty: false,
+    startLine: snapshot.startLine,
+    endLine: snapshot.endLine,
+  })
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
 } from './sessions'
 import { buildLaunchEnv, resolveLaunchCommand, detectShellKind, formatLaunchPath } from './session'
 import { buildAtMention, normalizeMentionPath } from './at-mention'
+import { decideAutoInsert } from './auto-mention'
 
 const TERMINAL_NAME = 'DeepSeek'
 
@@ -235,6 +236,59 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
     await vscode.env.clipboard.writeText(mention)
     void vscode.window.showInformationMessage(`已复制 ${mention},请粘贴到 dsh-tui 输入框`)
   })
+  // 选区变化自动引用(experimental,默认关):把官方「编辑器选区自动出现在会话
+  // 引用」在 dsh-tui 上降级近似为——选区变化 → 300ms 防抖 → 自动把
+  // `@绝对路径 L起-止` 键入运行中的 dsh-tui 输入框。官方 true 机制走
+  // `~/.claude/ide` WebSocket(`selection_changed`),dsh-tui 不消费该通道,
+  // 扩展只有 `terminal.sendText` 一条输入通道,故为降级近似;也因此必须：
+  // 默认关闭、仅在有运行中会话时注入、对同一选区去重,避免抢占输入框/刷屏。
+  // 监听器始终注册,回调内实时读配置(用户/E2E 改配置立即生效,无 attach
+  // 时序依赖 —— 也避免了「改配置后监听器未挂上」的竞态)。
+  {
+    let lastInserted: string | undefined
+    let postpone: ReturnType<typeof setTimeout> | undefined
+    const isEnabled = (): boolean =>
+      vscode.workspace
+        .getConfiguration('dsh-tui-vscode')
+        .get<boolean>('autoInsertMention', false)
+    context.subscriptions.push(
+      vscode.window.onDidChangeTextEditorSelection(event => {
+        if (!isEnabled()) return
+        const editor = event.textEditor
+        // 非文件 scheme(终端输出、diff 等)不注入;不等同于必须有
+        // activeTextEditor —— 官方实现同样不要求 active,程序化/焦点切换
+        // 时事件仍应工作(且后台编辑器选区通常不会变化,误触发风险低)。
+        if (editor.document.uri.scheme !== 'file') return
+        const selection = editor.selection
+        const outcome = decideAutoInsert({
+          enabled: true,
+          hasSelection: !selection.isEmpty,
+          hasTerminal: hasTerminal(),
+          snapshot: {
+            path: editor.document.uri.fsPath,
+            startLine: selection.start.line,
+            endLine: selection.end.line,
+          },
+          lastInserted,
+        })
+        if (outcome.action !== 'insert') return
+        // 300ms 防抖:连续拖选/多点只收敛为最后一次。
+        if (postpone !== undefined) clearTimeout(postpone)
+        postpone = setTimeout(() => {
+          const terminal = findTerminal()
+          if (!terminal) return
+          terminal.show()
+          terminal.sendText(outcome.mention, false)
+          lastInserted = outcome.mention
+        }, 300)
+      }),
+      {
+        dispose: () => {
+          if (postpone !== undefined) clearTimeout(postpone)
+        },
+      },
+    )
+  }
   register('dsh-tui-vscode.refreshSessions', () => {
     sessionsTree.refresh()
   })

--- a/src/test-suite/index.ts
+++ b/src/test-suite/index.ts
@@ -643,6 +643,60 @@ test('insertAtMention types the @-mention into the running session input', async
   }
 })
 
+test('autoInsertMention (experimental) auto-types the mention on selection change', async () => {
+  await configureFakeLauncher()
+  const cfg = vscode.workspace.getConfiguration('dsh-tui-vscode')
+  await cfg.update('autoInsertMention', true, vscode.ConfigurationTarget.Global)
+  try {
+    // Give the config-change handler time to arm the selection listener.
+    await sleep(400)
+    rmSync(ENV_OUT, { force: true })
+    rmSync(STDIN_OUT, { force: true })
+    await vscode.commands.executeCommand('dsh-tui-vscode.start')
+    await poll(() => (readFile(ENV_OUT)?.includes('FAKE_LAUNCHER_RAN') ? true : undefined), 20000)
+    await sleep(750)
+
+    const file = join(WS, 'e2e-auto-insert.ts')
+    writeFileSync(file, 'line0\nline1\nline2\nline3\n')
+    try {
+      const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(file))
+      const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false })
+      // A real selection change (non-empty) after arming — this is what the
+      // user "selecting code" produces; must auto-type after the debounce.
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 5))
+      const { normalizeMentionPath } = await import('../at-mention.js') as typeof import('../at-mention.js')
+      const expected = '@' + normalizeMentionPath(editor.document.uri.fsPath) + ' L1-3'
+
+      // Auto-inject fires after the 300ms debounce, WITHOUT any Enter — the
+      // mention stays in the dsh-tui input (exactly like manual insertAtMention:
+      // the user completes the question, then presses Enter). To observe it on
+      // the child's stdin, wait for the debounced inject to land in the terminal
+      // buffer, THEN simulate the Enter the user would press.
+      await sleep(700) // > 300ms debounce + terminal round-trip
+      ;(vscode.extensions.getExtension(EXT_ID)!.exports as Api).sendInput('\r')
+      let seen = false
+      try {
+        await poll(() => {
+          const content = readFile(STDIN_OUT)
+          return content?.includes(expected) ? true : undefined
+        }, 10000)
+        seen = true
+      } finally {
+        if (!seen) {
+          const stdin = readFile(STDIN_OUT) ?? '<empty>'
+          console.log(`[e2e] auto-insert diagnostic: expected=[${expected}] stdin=[${stdin.slice(0, 200)}] terminals=[${vscode.window.terminals.map(t => t.name).join(',')}]`)
+        }
+      }
+      assert.ok(seen, 'auto mention reached the running session input after user Enter')
+    } finally {
+      rmSync(file, { force: true })
+      await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+    }
+  } finally {
+    await cfg.update('autoInsertMention', false, vscode.ConfigurationTarget.Global)
+  }
+})
+
 export async function run(): Promise<void> {
   console.log(`[e2e] running ${tests.length} tests`)
   // Inject the fake launcher dir into PATH so the bare command

--- a/src/test/auto-mention.test.ts
+++ b/src/test/auto-mention.test.ts
@@ -1,0 +1,208 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildMentionForSnapshot,
+  decideAutoInsert,
+} from '../auto-mention.js'
+
+// ---------- 门控:默认关闭 ----------
+test('disabled setting always skips, even with selection and terminal', () => {
+  const result = decideAutoInsert({
+    enabled: false,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 11, endLine: 13 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'skip', reason: 'disabled' })
+})
+
+// ---------- 门控:空选区 ----------
+test('empty selection is skipped (no auto-inject on mere clicks)', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: false,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 0, endLine: 0 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'skip', reason: 'no-selection' })
+})
+
+test('cursor-only movement never triggers even when enabled', () => {
+  // 模拟:用户点击/移动光标(空选区),不应注入
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: false,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 5, endLine: 5 },
+    lastInserted: '...',
+  })
+  assert.equal(result.action, 'skip')
+})
+
+// ---------- 门控:无运行中会话 ----------
+test('no running terminal is skipped silently (no clipboard, no toast)', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: false,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 11, endLine: 13 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'skip', reason: 'no-terminal' })
+})
+
+// ---------- 去重 ----------
+test('identical selection right after an insert is deduplicated', () => {
+  const mention = '@D:/repo/src/a.ts L12-14'
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 11, endLine: 13 },
+    lastInserted: mention,
+  })
+  assert.deepEqual(result, { action: 'skip', reason: 'duplicate' })
+})
+
+test('same path but different range is NOT a duplicate (new mention)', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 11, endLine: 13 },
+    lastInserted: '@D:/repo/src/a.ts L12',
+  })
+  assert.equal(result.action, 'insert')
+  assert.equal(result.mention, '@D:/repo/src/a.ts L12-14')
+})
+
+// ---------- 正常注入:mention 构造 ----------
+test('multi-line selection produces @abs/path L1-2 (0-based → 1-based)', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 0, endLine: 1 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'insert', mention: '@D:/repo/src/a.ts L1-2' })
+})
+
+test('single-line selection uses a single line number', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: '/home/me/src/a.ts', startLine: 11, endLine: 11 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'insert', mention: '@/home/me/src/a.ts L12' })
+})
+
+test('windows backslash path is normalized to forward slashes before insert', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'C:\\Users\\me\\repo\\src\\a.ts', startLine: 2, endLine: 4 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'insert', mention: '@C:/Users/me/repo/src/a.ts L3-5' })
+})
+
+// ---------- 路径含空白 → 双引号形式 ----------
+test('path with whitespace uses the double-quoted mention form', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/My Some/a file.ts', startLine: 0, endLine: 1 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'insert', mention: '@"D:/My Some/a file.ts" L1-2' })
+})
+
+// ---------- 反转选区(reversed) ----------
+test('reversed selection still uses start..end in ascending order', () => {
+  // VS Code 的 selection.start/end 已经是规范序;即使 isReversed,start<end
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/src/a.ts', startLine: 5, endLine: 9 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'insert', mention: '@D:/repo/src/a.ts L6-10' })
+})
+
+// ---------- buildMentionForSnapshot 边界 ----------
+test('buildMentionForSnapshot passes through POSIX path unchanged', () => {
+  assert.equal(
+    buildMentionForSnapshot({ path: '/home/me/a.ts', startLine: 0, endLine: 0 }),
+    '@/home/me/a.ts L1',
+  )
+})
+
+test('buildMentionForSnapshot normalizes backslashes', () => {
+  assert.equal(
+    buildMentionForSnapshot({ path: 'C:\\repo\\b.ts', startLine: 12, endLine: 12 }),
+    '@C:/repo/b.ts L13',
+  )
+})
+
+// ---------- 组合门控:在边界下的全判定 ----------
+test('same selection after switching back is deduplicated only against last insert', () => {
+  // 用户选中 A 段 → 注入;切走 → 切回 A 段:lastInserted 仍是 A,所以去重跳过
+  const first = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/a.ts', startLine: 0, endLine: 2 },
+    lastInserted: undefined,
+  })
+  assert.equal(first.action, 'insert')
+  const again = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/a.ts', startLine: 0, endLine: 2 },
+    lastInserted: first.mention,
+  })
+  assert.deepEqual(again, { action: 'skip', reason: 'duplicate' })
+})
+
+test('first-selection-insert is never a duplicate', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/a.ts', startLine: 3, endLine: 5 },
+    lastInserted: undefined,
+  })
+  assert.equal(result.action, 'insert')
+})
+
+test('selection boundary at last line (0-based) maps to itself as 1-based', () => {
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/z.ts', startLine: 99, endLine: 99 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'insert', mention: '@D:/repo/z.ts L100' })
+})
+
+test('multi-cursor: report uses the primary selection only (start/end of primary)', () => {
+  // onDidChangeTextEditorSelection 的 editor.selection 是主选区,这里固定它
+  const result = decideAutoInsert({
+    enabled: true,
+    hasSelection: true,
+    hasTerminal: true,
+    snapshot: { path: 'D:/repo/m.ts', startLine: 20, endLine: 22 },
+    lastInserted: undefined,
+  })
+  assert.deepEqual(result, { action: 'insert', mention: '@D:/repo/m.ts L21-23' })
+})


### PR DESCRIPTION
## 摘要 / Summary

- 动机:issue 反馈 `Ctrl+Alt+K` 与 opencode 撞键时当前无说明;官方 Claude Code 的「选区自动出现在会话引用」在真实终端 dsh-tui 上无法直接照搬(无 `~/.claude/ide` WS 通道)。
- 做法:①README 增加快捷键冲突/重绑说明(中英镜像);②新增 experimental 配置 `dsh-tui-vscode.autoInsertMention`(默认 false),开启后选区变化→300ms 防抖→自动把 `@绝对路径 L起-止` 键入运行中的 dsh-tui 输入框;③docs 记录官方真实机制(§4.1)与降级近似设计(§4.2)。
- 影响:作为 **0.6.3** 发布。纯增量,默认关闭,不影响既有 `Ctrl+Alt+K`/右键/命令面板;CHANGELOG 已转 `[0.6.3]` 版本段(经 PR #10),README 徽章/package.json 五处一致 bump 0.6.3。

## 改动范围（勾选）/ Scope of Changes (check)

- [ ] 核心逻辑（终端 / 会话）/ Core logic (terminal / session)
- [ ] 会话历史（侧边栏）/ Session history (sidebar)
- [x] 文档（README / docs / CHANGELOG / CONTRIBUTING）/ Docs
- [x] 其他 / Other: 新增 experimental 自动选区引用 + 单测/e2e + 版本 bump 0.6.3

## 验证（勾选已执行）/ Verification (check executed)

- [x] 单元测试 / Unit tests（命令 + 结果 / command + result）: `npm test` → 61/61（含 17 条 auto-mention 边界单测）
- [x] 手动验证 / Manual verification（描述场景 / describe the scenario）: e2e `npm run test:e2e` → 16/16（真实 VS Code 宿主;新增 autoInsertMention 真实注入:选区变化→自动注入→用户回车→fake child stdin 收到 mention）
- [x] 文档改动：中英双语同步 / Doc changes: EN and ZH mirrored: README 176/176, CHANGELOG 行数差 2（与基线一致）
- [x] 关键验证输出已粘贴至验证段下方 / Key verification output pasted below: 见下
- [ ] 如有未运行的验证项（说明原因）/ Not run if any (explain):

关键验证输出（粘贴）:
- `npm test` → `tests 61 · pass 61 · fail 0`
- `npm run test:e2e` → `[e2e] all 16 tests passed`（含 PASS autoInsertMention (experimental) auto-types the mention on selection change）
- `npm run typecheck` → 无错误
- pre-commit: 61/61 单测 · 4 组双语镜像 · BOM 检查 · 凭据扫描 全过（两次 commit 均通过）
- 版本五处一致: package.json / README 徽章(中英) / CHANGELOG 首版本段(中英) = `0.6.3`

## 自查（勾选）/ Self-check (check)

- [x] 行为变化已记入 CHANGELOG(Unreleased)/ Behavior changes recorded in CHANGELOG (Unreleased)（已转 `[0.6.3]` 版本段,经 PR #10）
- [x] 版本号与实现一致 / Version number matches the implementation（五处一致 0.6.3;release-consistency 会校验）
- [x] 无无关文件或本地伪影 / No unrelated files or local artifacts（仅本次 10 个任务文件 + 5 个版本文件;不含 .gitignore/.scratch 等）

## 基于版本 / Based on

最新默认分支 `main`（`2c2629a` chore(release): 0.6.2）

## 关联（可选）/ Related (optional)

非解决性关联(文字描述,不引用 issue 编号):本次改动承接「引用选中代码」功能的键盘冲突反馈与选区自动化的方向;上游 dsh-TUI 的「相对路径 + #L 行区间」落地后,本 experimental 功能将升级为相对路径 + 行区间。

## 审查注意点 / Review Notes

- `autoInsertMention` 是 experimental 且默认关闭——审查重点是注入的门控(仅运行中会话、非空选区、300ms 防抖、同选区去重、非文件 scheme 排除)是否足够克制;
- e2e 断言依赖「注入后模拟用户回车」观察 stdin,该时序已在测试内固定(sleep 700 > 300ms 防抖);
- 版本 bump:本次含 `chore(release): 0.6.3`(五处一致),release-consistency CI 将校验;合并后按发布流程打 `v0.6.3` tag 并上传 vsix;
- 未引用 issue 编号:本 PR 并不解决既有 issue(如要闭合 #6 请指示,但 #6 的 @-mention 功能已在 0.6.2 实现)。