### PR TITLE
feat(dsh-ecosystem): v0.15 试点 manifest 与适配说明——官方校验入口证据 + 时效审计修订

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,14 @@ coverage/
 .vscode-test/
 npm-cache/
 .gh-log/
+.scratch/
 *.vsix
 *.log
 
 CLAUDE.md
+
+docs/superpowers/
+.specs/
 
 # 凭据
 .env

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -21,23 +21,23 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 | `permissions` | `commands.invoke`（单条；scope = 插件命名空间，覆盖 start/resume；dsh-std 投影按 action 去重，同一 action 不允许重复声明） |
 | `contributes.commands` | `dsh-tui-vscode.start` / `dsh-tui-vscode.resume` |
 | `subscriptions` | 无（当前不订阅 messages.observe 等事件） |
-| Host Descriptor | 官方示例已发布：上游 `registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，storage/commands/messages）；真实 dsh-tui host 未发布（见 D-2） |
+| Host Descriptor | 上游示例已发布：`registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，storage/commands/messages）；真实 dsh-tui host 未发布（见 D-2） |
 | effect ledger | 未实现；当前通过 VS Code 终端/会话文件系统读写，无标准 ledger |
 
 ## 已知偏差
 
 - **D-1 entry 不可被 dsh 直接加载**：`out/extension.js` 是 VS Code Extension Host 入口，不能由 dsh/Cordis 直接加载。当前 `dsh-plugin.json` 是“声明性试点”，不是可执行插件。
-- **D-2 无真实 Host Descriptor**：上游 dsh-ecosystem-spec 已发布官方示例 `registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，contracts=storage/commands/messages，hostVersion `0.1.0-experimental`），但 dsh-tui 运行时仍未发布可验证的“真实” Host Descriptor；本扩展自身也无法单独声明宿主能力。
+- **D-2 无真实 Host Descriptor**：上游 dsh-ecosystem-spec 已发布示例 `registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，contracts=storage/commands/messages，hostVersion `0.1.0-experimental`），但 dsh-tui 运行时仍未发布可验证的“真实” Host Descriptor；本扩展自身也无法单独声明宿主能力。
 - **D-3 无 effect ledger / lifecycle 实现**：当前没有 activation instance、runtime generation、effect ledger 等 v0.15 生命周期实体。
 - **D-4 与 Cordis bundle 双轨并存**：实际可运行层仍是 `package.json` 的 `dsh.bundle` + `cordis.patch.yml`；`dsh-plugin.json` 是额外试点声明，两者尚未统一。
-- **D-5 证据等级为 Declared**：试点 manifest 已通过上游 dsh-std v0.15 的 schema + 语义校验（`parseManifest` → `projectManifest` → `manifestDefinitions.validate`），并对官方示例 Host Descriptor（`registry/host-descriptor.tui.example.json`）协商出 **`compatible`**（无 required 缺失、无 denied permission）。但因 entry 不可被 dsh 直接加载（D-1）且真实 host 协商未发生，证据等级仍为 `Declared`，不能声称 `Tested` / `Verified`。
+- **D-5 证据等级为 Declared**：试点 manifest 已通过上游 dsh-std v0.15 的 schema + 语义校验（`parseManifest` → `projectManifest` → `manifestDefinitions.validate`），并对上游仓库的示例(example)Host Descriptor（`registry/host-descriptor.tui.example.json`）协商出 **`compatible`**（无 required 缺失、无 denied permission）。但因 entry 不可被 dsh 直接加载（D-1）且真实 host 协商未发生，证据等级仍为 `Declared`，不能声称 `Tested` / `Verified`。
 
 ## 证据
 
 - 仓库：https://github.com/baobaolaodie/dsh-tui-vscode
 - 分支：`feat/dsh-ecosystem-spec`
 - `dsh-plugin.json`：本仓库根目录（试点声明）
-- 上游 conformance 复核：T-Auto/dsh-ecosystem-spec（HEAD `e1b902b`，2026-08-18，含 tui.dsh 命名空间迁移）+ 固定 `vendor/dsh-std` submodule；`npm run test:standalone` 独立跑通官方 suite 全绿，并对试点 manifest 执行同款校验 → **`compatible`**（结构 + 语义 + 协商全过，迁移后仍合规）。
+- 上游 conformance 复核：T-Auto/dsh-ecosystem-spec（HEAD `e1b902b`，2026-08-18，含 tui.dsh 命名空间迁移）+ 固定 `vendor/dsh-std` submodule；`npm run test:standalone` 独立跑通上游 conformance suite 全绿，并对试点 manifest 执行同款校验 → **`compatible`**（结构 + 语义 + 协商全过，迁移后仍合规）。
 - 注：上游 [PR #2](https://github.com/T-Auto/dsh-ecosystem-spec/pull/2)（conformance 加载对齐）已合并，修复早期「独立检出无法运行」问题；独立检出现在用 `npm run test:standalone`（等价 `node scripts/conformance.mjs --standalone`）。
 - 已合入上游：本 Note 已随 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3) 合入 `adapters/dsh-tui-vscode-v0.15.md`（生态首篇 Adapter Note；README 生态扩展表第一行）。
 - 现有 CI：`npm test` / `npm run test:e2e` 覆盖 VS Code 扩展行为，不覆盖 v0.15 conformance。

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -30,22 +30,28 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 - **D-2 无真实 Host Descriptor**：上游 dsh-ecosystem-spec 已发布示例 `registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，contracts=storage/commands/messages，hostVersion `0.1.0-experimental`），但 dsh-tui 运行时仍未发布可验证的“真实” Host Descriptor；本扩展自身也无法单独声明宿主能力。
 - **D-3 无 effect ledger / lifecycle 实现**：当前没有 activation instance、runtime generation、effect ledger 等 v0.15 生命周期实体。
 - **D-4 与 Cordis bundle 双轨并存**：实际可运行层仍是 `package.json` 的 `dsh.bundle` + `cordis.patch.yml`；`dsh-plugin.json` 是额外试点声明，两者尚未统一。
-- **D-5 证据等级为 Declared**：试点 manifest 已通过上游 dsh-std v0.15 的 schema + 语义校验（`parseManifest` → `projectManifest` → `manifestDefinitions.validate`），并对上游仓库的示例(example)Host Descriptor（`registry/host-descriptor.tui.example.json`）协商出 **`compatible`**（无 required 缺失、无 denied permission）。但因 entry 不可被 dsh 直接加载（D-1）且真实 host 协商未发生，证据等级仍为 `Declared`，不能声称 `Tested` / `Verified`。
+- **D-5 证据等级为 Declared**：试点 manifest 已通过上游 dsh-std v0.15 的 schema + 语义校验（`parseManifest` → `projectManifest` → `manifestDefinitions.validate`），并对上游仓库的示例(example)Host Descriptor（`registry/host-descriptor.tui.example.json`）协商出 **`compatible`**（无 required 缺失、无 denied permission）。2026-08-21 起该复核可经官方入口 `npm run validate:manifest` 一键复现（上游 PR #5）。但因 entry 不可被 dsh 直接加载（D-1）且真实 host 协商未发生，证据等级仍为 `Declared`，不能声称 `Tested` / `Verified`。
 
 ## 证据
 
 - 仓库：https://github.com/baobaolaodie/dsh-tui-vscode
 - 分支：`feat/dsh-ecosystem-spec`
 - `dsh-plugin.json`：本仓库根目录（试点声明）
-- 上游 conformance 复核：T-Auto/dsh-ecosystem-spec（HEAD `e1b902b`，2026-08-18，含 tui.dsh 命名空间迁移）+ 固定 `vendor/dsh-std` submodule；`npm run test:standalone` 独立跑通上游 conformance suite 全绿，并对试点 manifest 执行同款校验 → **`compatible`**（结构 + 语义 + 协商全过，迁移后仍合规）。
+- 上游 conformance 复核（2026-08-22 更新）：T-Auto/dsh-ecosystem-spec main HEAD `d406de4`（含 PR #5 官方校验入口）+ 固定 `vendor/dsh-std` @ `614dfa1`：
+  - `npm run test:standalone` 全量 suite 退出码 0（manifest/Host Descriptor/envelope/ledger/claim 正反 fixture 与五态协商矩阵全部符合预期）；
+  - 官方入口 `npm run validate:manifest -- --manifest ./dsh-plugin.json --host registry/host-descriptor.tui.example.json` → `{"valid":true,"decision":"compatible","missingOptional":[]}`，exit 0；
+  - 结论维持 **`compatible`**（结构 + 语义 + 协商全过；PR #5 将 admission 算法抽为共用核心 `admission-core.js` 后复核结论不变）。
 - 注：上游 [PR #2](https://github.com/T-Auto/dsh-ecosystem-spec/pull/2)（conformance 加载对齐）已合并，修复早期「独立检出无法运行」问题；独立检出现在用 `npm run test:standalone`（等价 `node scripts/conformance.mjs --standalone`）。
-- 已合入上游：本 Note 已随 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3) 合入 `adapters/dsh-tui-vscode-v0.15.md`（生态首篇 Adapter Note；README 生态扩展表第一行）。
+- 已合入上游：本 Note 已随 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3) 合入 `adapters/dsh-tui-vscode-v0.15.md`（生态首篇 Adapter Note；曾列于 README「生态扩展一览表」首行，该表后被上游提交 `69052fd` 移除，见「上游演变跟踪」）。
 - 现有 CI：`npm test` / `npm run test:e2e` 覆盖 VS Code 扩展行为，不覆盖 v0.15 conformance。
 
 ## 上游演变跟踪
 
 - **2026-08-18 命名空间迁移（PR #4）**：上游把 TUI 私有命名空间 `x-ccch1mneyyy.tui/*` 统一迁移为中性 `tui.dsh/*`（DecisionEvents / Channel / SettingsSection / Scene，坐标 `tui.dsh/v1alpha1`），旧坐标不作隐式别名（协商保持确定性）。**本试点 `requires.contracts` 仅使用 std 的 `commands.dsh/v1alpha1#Command`，不消费任何 `tui.dsh` 私有坐标，故迁移不影响本试点**；若未来使用 TUI 私有能力，须改用 `tui.dsh/v1alpha1` 坐标。
 - **2026-08-18 conformance 可独立跑**：PR #2 合并后 `npm run test:standalone` 可独立验证（31 fixture + 五态协商全绿）；本试点在其上复核结论仍为 `compatible`。
+- **2026-08-21 官方单插件校验入口（PR #5）**：admission 算法自 `conformance/tests/run.js` 抽出为共用核心 `conformance/tests/admission-core.js`，新增 `npm run validate:manifest -- --manifest ./dsh-plugin.json [--host ...] [--grant ...]`（exit 0 = compatible / compatible_degraded / waiting_authorization）。本试点早期的「同款逻辑手工复刻」取证方式自此可由官方 CLI 一键复现。
+- **2026-08-21 RFC 0009（供应链事件响应）未合入 main**：位于上游分支 `dev-supply-chain-vision`（撤销注册表 `registry/retractions-0.15.json`、PLUGIN-ADMISSION-CHECKLIST / SECURITY / governance 增补）。对现行 v0.15 准入无约束力，本试点保持观察。
+- **2026-08-18~22 README 门面重写**：提交 `69052fd` 移除「生态扩展一览表」对本仓库与 Adapter Note 的直达链接，生态可见性转由 [tui 插件市场](https://dshtui.com/plugins/)承担（README 徽章口径收录 23 个）；Note 文件本身仍在 `adapters/` 且被上游 `package.json` 的 `files` 收录。同期规范本体零漂移（spec / registry / schemas / `vendor/dsh-std` @ `614dfa1` 均未动）。
 
 ## 收敛计划
 
@@ -53,4 +59,4 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 2. 等 Cordis 或 dsh loader 支持读取 `dsh-plugin.json` 作为包身份层；
 3. 再决定 entry 是否需要改为独立的 Node/Cordis 入口；
 4. 届时补 effect ledger 与 lifecycle 映射，并从 `Declared` 升级到更高证据等级；
-5. 本 Note 作为第一篇 Adapter Note 提交上游 `adapters/`（T-Auto/dsh-ecosystem-spec PR #3，作为社区首个 VS Code companion 适配参考）。
+5. 本 Note 已作为第一篇 Adapter Note 随 T-Auto/dsh-ecosystem-spec PR #3 合入上游 `adapters/`（生态首个 VS Code companion 适配参考）；后续增量（证据升级、上游演变跟踪）再以小 PR 向上游同步。

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -37,10 +37,15 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 - 仓库：https://github.com/baobaolaodie/dsh-tui-vscode
 - 分支：`feat/dsh-ecosystem-spec`
 - `dsh-plugin.json`：本仓库根目录（试点声明）
-- 上游 conformance 核对：T-Auto/dsh-ecosystem-spec（HEAD `aca48d8`，2026-08-18）+ 固定 `vendor/dsh-std` submodule；以 `conformance/tests/run.js` 同款逻辑对试点 manifest 重新执行校验 → **`compatible`**（结构校验 + 语义校验 + 协商全部通过）。
-- 注：上游完整 `pnpm test` 在独立 checkout 下暂因 [PR #2](https://github.com/T-Auto/dsh-ecosystem-spec/pull/2)（`protocols/tui-channel.js` 裸引用 `@dsh-std/connection`）导入失败，属上游已知开放问题，与试点 manifest 无关。
-- 已提交上游：本 Note 的上游镜像见 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3)（`adapters/dsh-tui-vscode-v0.15.md`）。
+- 上游 conformance 复核：T-Auto/dsh-ecosystem-spec（HEAD `e1b902b`，2026-08-18，含 tui.dsh 命名空间迁移）+ 固定 `vendor/dsh-std` submodule；`npm run test:standalone` 独立跑通官方 suite 全绿，并对试点 manifest 执行同款校验 → **`compatible`**（结构 + 语义 + 协商全过，迁移后仍合规）。
+- 注：上游 [PR #2](https://github.com/T-Auto/dsh-ecosystem-spec/pull/2)（conformance 加载对齐）已合并，修复早期「独立检出无法运行」问题；独立检出现在用 `npm run test:standalone`（等价 `node scripts/conformance.mjs --standalone`）。
+- 已合入上游：本 Note 已随 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3) 合入 `adapters/dsh-tui-vscode-v0.15.md`（生态首篇 Adapter Note；README 生态扩展表第一行）。
 - 现有 CI：`npm test` / `npm run test:e2e` 覆盖 VS Code 扩展行为，不覆盖 v0.15 conformance。
+
+## 上游演变跟踪
+
+- **2026-08-18 命名空间迁移（PR #4）**：上游把 TUI 私有命名空间 `x-ccch1mneyyy.tui/*` 统一迁移为中性 `tui.dsh/*`（DecisionEvents / Channel / SettingsSection / Scene，坐标 `tui.dsh/v1alpha1`），旧坐标不作隐式别名（协商保持确定性）。**本试点 `requires.contracts` 仅使用 std 的 `commands.dsh/v1alpha1#Command`，不消费任何 `tui.dsh` 私有坐标，故迁移不影响本试点**；若未来使用 TUI 私有能力，须改用 `tui.dsh/v1alpha1` 坐标。
+- **2026-08-18 conformance 可独立跑**：PR #2 合并后 `npm run test:standalone` 可独立验证（31 fixture + 五态协商全绿）；本试点在其上复核结论仍为 `compatible`。
 
 ## 收敛计划
 

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -18,25 +18,28 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 | `facets.host.entry` | `out/extension.js`（VS Code 扩展入口；**非 dsh 宿主可执行入口**，见偏差 D-1） |
 | `facets.host.apiVersion` | `v1alpha1`（试点值；尚未被 dsh-tui 运行时协商） |
 | `requires.contracts` | `commands.dsh/v1alpha1` + `Command`（启动/恢复命令的声明） |
-| `permissions` | `commands.invoke`（scope 限定到本插件声明的命令 ID） |
+| `permissions` | `commands.invoke`（单条；scope = 插件命名空间，覆盖 start/resume；dsh-std 投影按 action 去重，同一 action 不允许重复声明） |
 | `contributes.commands` | `dsh-tui-vscode.start` / `dsh-tui-vscode.resume` |
 | `subscriptions` | 无（当前不订阅 messages.observe 等事件） |
-| Host Descriptor | 未发布；dsh-tui 本体尚未提供真实 Host Descriptor |
+| Host Descriptor | 官方示例已发布：上游 `registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，storage/commands/messages）；真实 dsh-tui host 未发布（见 D-2） |
 | effect ledger | 未实现；当前通过 VS Code 终端/会话文件系统读写，无标准 ledger |
 
 ## 已知偏差
 
 - **D-1 entry 不可被 dsh 直接加载**：`out/extension.js` 是 VS Code Extension Host 入口，不能由 dsh/Cordis 直接加载。当前 `dsh-plugin.json` 是“声明性试点”，不是可执行插件。
-- **D-2 无 Host Descriptor**：dsh-tui 本体还没有发布符合 `host-descriptor.schema.json` 的真实 Host Descriptor；本仓库也无法单独声明宿主能力。
+- **D-2 无真实 Host Descriptor**：上游 dsh-ecosystem-spec 已发布官方示例 `registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，contracts=storage/commands/messages，hostVersion `0.1.0-experimental`），但 dsh-tui 运行时仍未发布可验证的“真实” Host Descriptor；本扩展自身也无法单独声明宿主能力。
 - **D-3 无 effect ledger / lifecycle 实现**：当前没有 activation instance、runtime generation、effect ledger 等 v0.15 生命周期实体。
 - **D-4 与 Cordis bundle 双轨并存**：实际可运行层仍是 `package.json` 的 `dsh.bundle` + `cordis.patch.yml`；`dsh-plugin.json` 是额外试点声明，两者尚未统一。
-- **D-5 未通过 conformance negotiation**：因为缺少真实 Host Descriptor 和可加载 entry，当前只能达到 `Declared` 级，不能声称 `Tested` / `Verified`。
+- **D-5 证据等级为 Declared**：试点 manifest 已通过上游 dsh-std v0.15 的 schema + 语义校验（`parseManifest` → `projectManifest` → `manifestDefinitions.validate`），并对官方示例 Host Descriptor（`registry/host-descriptor.tui.example.json`）协商出 **`compatible`**（无 required 缺失、无 denied permission）。但因 entry 不可被 dsh 直接加载（D-1）且真实 host 协商未发生，证据等级仍为 `Declared`，不能声称 `Tested` / `Verified`。
 
 ## 证据
 
 - 仓库：https://github.com/baobaolaodie/dsh-tui-vscode
 - 分支：`feat/dsh-ecosystem-spec`
 - `dsh-plugin.json`：本仓库根目录（试点声明）
+- 上游 conformance 核对：T-Auto/dsh-ecosystem-spec（HEAD `aca48d8`，2026-08-18）+ 固定 `vendor/dsh-std` submodule；以 `conformance/tests/run.js` 同款逻辑对试点 manifest 重新执行校验 → **`compatible`**（结构校验 + 语义校验 + 协商全部通过）。
+- 注：上游完整 `pnpm test` 在独立 checkout 下暂因 [PR #2](https://github.com/T-Auto/dsh-ecosystem-spec/pull/2)（`protocols/tui-channel.js` 裸引用 `@dsh-std/connection`）导入失败，属上游已知开放问题，与试点 manifest 无关。
+- 已提交上游：本 Note 的上游镜像见 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3)（`adapters/dsh-tui-vscode-v0.15.md`）。
 - 现有 CI：`npm test` / `npm run test:e2e` 覆盖 VS Code 扩展行为，不覆盖 v0.15 conformance。
 
 ## 收敛计划
@@ -44,4 +47,5 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 1. 等 dsh-tui 本体发布真实 Host Descriptor；
 2. 等 Cordis 或 dsh loader 支持读取 `dsh-plugin.json` 作为包身份层；
 3. 再决定 entry 是否需要改为独立的 Node/Cordis 入口；
-4. 届时补 effect ledger 与 lifecycle 映射，并从 `Declared` 升级到更高证据等级。
+4. 届时补 effect ledger 与 lifecycle 映射，并从 `Declared` 升级到更高证据等级；
+5. 本 Note 作为第一篇 Adapter Note 提交上游 `adapters/`（T-Auto/dsh-ecosystem-spec PR #3，作为社区首个 VS Code companion 适配参考）。

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -21,14 +21,14 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 | `permissions` | `commands.invoke`（单条；scope = 插件命名空间，覆盖 start/resume；dsh-std 投影按 action 去重，同一 action 不允许重复声明） |
 | `contributes.commands` | `dsh-tui-vscode.start` / `dsh-tui-vscode.resume` |
 | `subscriptions` | 无（当前不订阅 messages.observe 等事件） |
-| Host Descriptor | 上游示例已发布：`registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，storage/commands/messages）；真实 dsh-tui host 未发布（见 D-2） |
+| Host Descriptor | 上游示例已发布：`registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，storage/commands/messages）；dsh-tui 已在运行时构建真实 descriptor 但无发布工件（见 D-2） |
 | effect ledger | 未实现；当前通过 VS Code 终端/会话文件系统读写，无标准 ledger |
 
 ## 已知偏差
 
 - **D-1 entry 不可被 dsh 直接加载**：`out/extension.js` 是 VS Code Extension Host 入口，不能由 dsh/Cordis 直接加载。当前 `dsh-plugin.json` 是“声明性试点”，不是可执行插件。
-- **D-2 无真实 Host Descriptor**：上游 dsh-ecosystem-spec 已发布示例 `registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，contracts=storage/commands/messages，hostVersion `0.1.0-experimental`），但 dsh-tui 运行时仍未发布可验证的“真实” Host Descriptor；本扩展自身也无法单独声明宿主能力。
-- **D-3 无 effect ledger / lifecycle 实现**：当前没有 activation instance、runtime generation、effect ledger 等 v0.15 生命周期实体。
+- **D-2 真实 Host Descriptor 已在运行时构建，但无可复验工件、未实测协商（2026-08-23 修订）**：dsh-TUI 主仓已落地 Host Descriptor 构建（`ctx.tuiPluginHost` 提供 runtime generationId，按运行代码真实挂载的契约动态声明，未挂载的 Command 契约剔除并告警）；但 spec 仓库 `registry/` 仍只有示例工件 `host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`），没有可供离线 `validate:manifest --host` 复验的「真实」descriptor 发布物，本扩展也尚未对运行中 dsh-tui 导出的 descriptor 实测协商。证据等级维持 `Declared` 的理由由「宿主侧不存在」修正为「尚未实测 + 工件未发布」。
+- **D-3 本插件侧未接入 effect ledger / lifecycle（2026-08-23 修订）**：宿主侧生命周期实体已实现——dsh-TUI 的效果台账（C-060，`~/.dsh-tui/effect-ledger.jsonl`，pluginId / activationInstance / runtimeGenerationId 三元组）与统一授权存储均已上线；偏差收窄为本扩展作为 VS Code companion 未声明 activation instance、未接入宿主台账，行为仍走 VS Code 终端与会话文件系统。
 - **D-4 与 Cordis bundle 双轨并存**：实际可运行层仍是 `package.json` 的 `dsh.bundle` + `cordis.patch.yml`；`dsh-plugin.json` 是额外试点声明，两者尚未统一。
 - **D-5 证据等级为 Declared**：试点 manifest 已通过上游 dsh-std v0.15 的 schema + 语义校验（`parseManifest` → `projectManifest` → `manifestDefinitions.validate`），并对上游仓库的示例(example)Host Descriptor（`registry/host-descriptor.tui.example.json`）协商出 **`compatible`**（无 required 缺失、无 denied permission）。2026-08-21 起该复核可经官方入口 `npm run validate:manifest` 一键复现（上游 PR #5）。但因 entry 不可被 dsh 直接加载（D-1）且真实 host 协商未发生，证据等级仍为 `Declared`，不能声称 `Tested` / `Verified`。
 
@@ -50,12 +50,13 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 - **2026-08-18 命名空间迁移（PR #4）**：上游把 TUI 私有命名空间 `x-ccch1mneyyy.tui/*` 统一迁移为中性 `tui.dsh/*`（DecisionEvents / Channel / SettingsSection / Scene，坐标 `tui.dsh/v1alpha1`），旧坐标不作隐式别名（协商保持确定性）。**本试点 `requires.contracts` 仅使用 std 的 `commands.dsh/v1alpha1#Command`，不消费任何 `tui.dsh` 私有坐标，故迁移不影响本试点**；若未来使用 TUI 私有能力，须改用 `tui.dsh/v1alpha1` 坐标。
 - **2026-08-18 conformance 可独立跑**：PR #2 合并后 `npm run test:standalone` 可独立验证（31 fixture + 五态协商全绿）；本试点在其上复核结论仍为 `compatible`。
 - **2026-08-21 官方单插件校验入口（PR #5）**：admission 算法自 `conformance/tests/run.js` 抽出为共用核心 `conformance/tests/admission-core.js`，新增 `npm run validate:manifest -- --manifest ./dsh-plugin.json [--host ...] [--grant ...]`（exit 0 = compatible / compatible_degraded / waiting_authorization）。本试点早期的「同款逻辑手工复刻」取证方式自此可由官方 CLI 一键复现。
-- **2026-08-21 RFC 0009（供应链事件响应）未合入 main**：位于上游分支 `dev-supply-chain-vision`（撤销注册表 `registry/retractions-0.15.json`、PLUGIN-ADMISSION-CHECKLIST / SECURITY / governance 增补）。对现行 v0.15 准入无约束力，本试点保持观察。
+- **2026-08-21 RFC 0009 转正为 [PR #8](https://github.com/T-Auto/dsh-ecosystem-spec/pull/8)（open，分支 `dev-supply-chain-vision`）**：维护者本人以正式 PR 提交供应链事件响应——撤销注册表 `registry/retractions-0.15.json`（yanked/deleted 双语义、append-only）与 PLUGIN-ADMISSION-CHECKLIST / SECURITY / governance 增补；自述对现有坐标/schema/registry **零兼容性影响**（纯新增层、旧 parser 忽略未知字段），并顺带把此前缺失的 TUI-OBS-002 / TUI-DEP-001 / TUI-CLAIM-001 / TUI-RUN-001/002 补录进 requirements 矩阵。合并概率高；若合入需评估消费端要求（TUI-SC-003 yanked/deleted 处理）对本试点的影响。
 - **2026-08-18~22 README 门面重写**：提交 `69052fd` 移除「生态扩展一览表」对本仓库与 Adapter Note 的直达链接，生态可见性转由 [tui 插件市场](https://dshtui.com/plugins/)承担（README 徽章口径收录 23 个）；Note 文件本身仍在 `adapters/` 且被上游 `package.json` 的 `files` 收录。同期规范本体零漂移（spec / registry / schemas / `vendor/dsh-std` @ `614dfa1` 均未动）。
+- **2026-08-23 时效审计：dsh-TUI 主仓已落地宿主侧**：[docs/plugins.md](https://github.com/ccch1mneyyy/dsh-TUI/blob/main/docs/plugins.md) 新增「社区互操作规范（Community Consensus v0.15）」章节——`src/plugin-spec/` 校验/协商纯库、vendored profile + `npm run verify:plugin-spec` 漂移检查、Host Descriptor 构建、统一授权存储（8 个注册权限，`commands.invoke` 默认允许）、效果台账与 `/plugins` 诊断面均标记为已落地；边界声明加载强制仍归 dsh CLI Loader。另：全网 `filename:dsh-plugin.json` 命中已达 200+（含多个真实社区插件仓），manifest 格式正在扩散。据此改写本 Note D-2/D-3。
 
 ## 收敛计划
 
-1. 等 dsh-tui 本体发布真实 Host Descriptor；
+1. 对运行中 dsh-tui 构建的真实 Host Descriptor 实测协商（spec registry 尚无可直接消费的发布工件，需经 `/plugins` 诊断面或宿主导出）；
 2. 等 Cordis 或 dsh loader 支持读取 `dsh-plugin.json` 作为包身份层；
 3. 再决定 entry 是否需要改为独立的 Node/Cordis 入口；
 4. 届时补 effect ledger 与 lifecycle 映射，并从 `Declared` 升级到更高证据等级；

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -18,8 +18,8 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 | `facets.host.entry` | `out/extension.js`（VS Code 扩展入口；**非 dsh 宿主可执行入口**，见偏差 D-1） |
 | `facets.host.apiVersion` | `v1alpha1`（试点值；尚未被 dsh-tui 运行时协商） |
 | `requires.contracts` | `commands.dsh/v1alpha1` + `Command`（启动/恢复命令的声明） |
-| `permissions` | `commands.invoke`（单条；scope = 插件命名空间，覆盖 start/resume；dsh-std 投影按 action 去重，同一 action 不允许重复声明） |
-| `contributes.commands` | `dsh-tui-vscode.start` / `dsh-tui-vscode.resume` |
+| `permissions` | `commands.invoke`（单条；scope 必须是已声明命令 id——宿主正向校验 scope∈commandIds、反向校验每命令必有对应授权，而 std 解析层按 name 去重禁止同 name 多条。当前仅声明 `.start`，`.resume` 待上游裁决后恢复，见 Gap 3） |
+| `contributes.commands` | 当前仅声明 `com.baobaolaodie.dsh-tui-vscode.start`（`.resume` 因 Gap 3 规则冲突暂缓，扩展本体仍提供该命令） |
 | `subscriptions` | 无（当前不订阅 messages.observe 等事件） |
 | Host Descriptor | 上游示例已发布：`registry/host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`，storage/commands/messages）；dsh-tui 已在运行时构建真实 descriptor 但无发布工件（见 D-2） |
 | effect ledger | 未实现；当前通过 VS Code 终端/会话文件系统读写，无标准 ledger |
@@ -41,6 +41,7 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
   - `npm run test:standalone` 全量 suite 退出码 0（manifest/Host Descriptor/envelope/ledger/claim 正反 fixture 与五态协商矩阵全部符合预期）；
   - 官方入口 `npm run validate:manifest -- --manifest ./dsh-plugin.json --host registry/host-descriptor.tui.example.json` → `{"valid":true,"decision":"compatible","missingOptional":[]}`，exit 0；
   - 结论维持 **`compatible`**（结构 + 语义 + 协商全过；PR #5 将 admission 算法抽为共用核心 `admission-core.js` 后复核结论不变）。
+- 宿主侧复核（2026-08-23，headless 复刻 `/plugins check` 全链：parseManifest → projectManifest → createContractIndex(vendored registry/permissions) → validatePlugin → buildHostDescriptor → negotiate，dsh-tui 0.8.8 安装副本）：**TUI semantic validation PASS**，negotiate → **`compatible`**（host.dropped=[] / warnings=[]）；最小合规形态（单命令 `.start`）；真实终端留档待补。
 - 注：上游 [PR #2](https://github.com/T-Auto/dsh-ecosystem-spec/pull/2)（conformance 加载对齐）已合并，修复早期「独立检出无法运行」问题；独立检出现在用 `npm run test:standalone`（等价 `node scripts/conformance.mjs --standalone`）。
 - 已合入上游：本 Note 已随 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3) 合入 `adapters/dsh-tui-vscode-v0.15.md`（生态首篇 Adapter Note；曾列于 README「生态扩展一览表」首行，该表后被上游提交 `69052fd` 移除，见「上游演变跟踪」）。
 - 现有 CI：`npm test` / `npm run test:e2e` 覆盖 VS Code 扩展行为，不覆盖 v0.15 conformance。
@@ -54,10 +55,13 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 - **2026-08-18~22 README 门面重写**：提交 `69052fd` 移除「生态扩展一览表」对本仓库与 Adapter Note 的直达链接，生态可见性转由 [tui 插件市场](https://dshtui.com/plugins/)承担（README 徽章口径收录 23 个）；Note 文件本身仍在 `adapters/` 且被上游 `package.json` 的 `files` 收录。同期规范本体零漂移（spec / registry / schemas / `vendor/dsh-std` @ `614dfa1` 均未动）。
 - **2026-08-23 时效审计：dsh-TUI 主仓已落地宿主侧**：[docs/plugins.md](https://github.com/ccch1mneyyy/dsh-TUI/blob/main/docs/plugins.md) 新增「社区互操作规范（Community Consensus v0.15）」章节——`src/plugin-spec/` 校验/协商纯库、vendored profile + `npm run verify:plugin-spec` 漂移检查、Host Descriptor 构建、统一授权存储（8 个注册权限，`commands.invoke` 默认允许）、效果台账与 `/plugins` 诊断面均标记为已落地；边界声明加载强制仍归 dsh CLI Loader。另：全网 `filename:dsh-plugin.json` 命中已达 200+（含多个真实社区插件仓），manifest 格式正在扩散。据此改写本 Note D-2/D-3。
 
+- **2026-08-23 实测发现上游规则缺陷（Gap 3）**：经运行中 dsh-tui（0.8.8，`/plugins check`）实测本试点 manifest 暴露——@dsh-std/manifest 0.1.0 解析层按 `community.dsh/v1alpha1␀Permission␀<name>` 去重（同 name 仅一条，scope 不参与），而 dsh-tui profile 层要求「每条 `commands.invoke` 的 scope 必须是已声明命令 id」且反向要求「每个已声明命令都有对应 invoke 授权」。三条规则合取下，**声明 ≥2 个命令的插件不存在可过审形态**。本试点暂以单命令（`.start`）最小合规形态保持双侧全绿；详见 `docs/gap-reports.md` Gap 3。
+
 ## 收敛计划
 
-1. 对运行中 dsh-tui 构建的真实 Host Descriptor 实测协商（spec registry 尚无可直接消费的发布工件，需经 `/plugins` 诊断面或宿主导出）；
-2. 等 Cordis 或 dsh loader 支持读取 `dsh-plugin.json` 作为包身份层；
-3. 再决定 entry 是否需要改为独立的 Node/Cordis 入口；
-4. 届时补 effect ledger 与 lifecycle 映射，并从 `Declared` 升级到更高证据等级；
-5. 本 Note 已作为第一篇 Adapter Note 随 T-Auto/dsh-ecosystem-spec PR #3 合入上游 `adapters/`（生态首个 VS Code companion 适配参考）；后续增量（证据升级、上游演变跟踪）再以小 PR 向上游同步。
+1. 以 `/plugins check` 对运行中 dsh-tui 完成真实宿主协商留档（headless 复刻链已 PASS + compatible，真实终端复核待补）；
+2. 上游裁决 Gap 3（多命令权限语义冲突）后恢复 `resume` 命令与第二条 invoke 授权声明；
+3. 等 Cordis 或 dsh loader 支持读取 `dsh-plugin.json` 作为包身份层；
+4. 再决定 entry 是否需要改为独立的 Node/Cordis 入口；
+5. 届时补 effect ledger 与 lifecycle 映射，并从 `Declared` 升级到更高证据等级；
+6. 本 Note 已作为第一篇 Adapter Note 随 T-Auto/dsh-ecosystem-spec PR #3 合入上游 `adapters/`（生态首个 VS Code companion 适配参考）；后续增量（证据升级、上游演变跟踪）再以小 PR 向上游同步。

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -1,0 +1,47 @@
+# Adapter Note — dsh-tui-vscode (VS Code companion) v0.15
+
+**Status:** Draft / Experimental
+**Spec version:** community-v0.15
+**Host:** dsh-TUI 0.7.0+ / Cordis 4.x profile; VS Code Extension API ^1.90.0
+**Plugin:** `com.baobaolaodie.dsh-tui-vscode` (pilot declaration)
+
+## 定位
+
+dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里的角色是“启动/恢复 dsh-TUI 会话的入口提供者”，而不是一个独立的 Cordis 运行时插件。
+
+本 Note 记录 dsh-ecosystem-spec v0.15 的 manifest 概念如何映射到该仓库现有实现，以及当前试点声明与规范之间的已知偏差。
+
+## Contract 映射
+
+| Community v0.15 概念 | dsh-tui-vscode 现状 |
+| --- | --- |
+| `facets.host.entry` | `out/extension.js`（VS Code 扩展入口；**非 dsh 宿主可执行入口**，见偏差 D-1） |
+| `facets.host.apiVersion` | `v1alpha1`（试点值；尚未被 dsh-tui 运行时协商） |
+| `requires.contracts` | `commands.dsh/v1alpha1` + `Command`（启动/恢复命令的声明） |
+| `permissions` | `commands.invoke`（scope 限定到本插件声明的命令 ID） |
+| `contributes.commands` | `dsh-tui-vscode.start` / `dsh-tui-vscode.resume` |
+| `subscriptions` | 无（当前不订阅 messages.observe 等事件） |
+| Host Descriptor | 未发布；dsh-tui 本体尚未提供真实 Host Descriptor |
+| effect ledger | 未实现；当前通过 VS Code 终端/会话文件系统读写，无标准 ledger |
+
+## 已知偏差
+
+- **D-1 entry 不可被 dsh 直接加载**：`out/extension.js` 是 VS Code Extension Host 入口，不能由 dsh/Cordis 直接加载。当前 `dsh-plugin.json` 是“声明性试点”，不是可执行插件。
+- **D-2 无 Host Descriptor**：dsh-tui 本体还没有发布符合 `host-descriptor.schema.json` 的真实 Host Descriptor；本仓库也无法单独声明宿主能力。
+- **D-3 无 effect ledger / lifecycle 实现**：当前没有 activation instance、runtime generation、effect ledger 等 v0.15 生命周期实体。
+- **D-4 与 Cordis bundle 双轨并存**：实际可运行层仍是 `package.json` 的 `dsh.bundle` + `cordis.patch.yml`；`dsh-plugin.json` 是额外试点声明，两者尚未统一。
+- **D-5 未通过 conformance negotiation**：因为缺少真实 Host Descriptor 和可加载 entry，当前只能达到 `Declared` 级，不能声称 `Tested` / `Verified`。
+
+## 证据
+
+- 仓库：https://github.com/baobaolaodie/dsh-tui-vscode
+- 分支：`feat/dsh-ecosystem-spec`
+- `dsh-plugin.json`：本仓库根目录（试点声明）
+- 现有 CI：`npm test` / `npm run test:e2e` 覆盖 VS Code 扩展行为，不覆盖 v0.15 conformance。
+
+## 收敛计划
+
+1. 等 dsh-tui 本体发布真实 Host Descriptor；
+2. 等 Cordis 或 dsh loader 支持读取 `dsh-plugin.json` 作为包身份层；
+3. 再决定 entry 是否需要改为独立的 Node/Cordis 入口；
+4. 届时补 effect ledger 与 lifecycle 映射，并从 `Declared` 升级到更高证据等级。

--- a/docs/adapters/dsh-tui-vscode-v0.15.md
+++ b/docs/adapters/dsh-tui-vscode-v0.15.md
@@ -27,7 +27,7 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 ## 已知偏差
 
 - **D-1 entry 不可被 dsh 直接加载**：`out/extension.js` 是 VS Code Extension Host 入口，不能由 dsh/Cordis 直接加载。当前 `dsh-plugin.json` 是“声明性试点”，不是可执行插件。
-- **D-2 真实 Host Descriptor 已在运行时构建，但无可复验工件、未实测协商（2026-08-23 修订）**：dsh-TUI 主仓已落地 Host Descriptor 构建（`ctx.tuiPluginHost` 提供 runtime generationId，按运行代码真实挂载的契约动态声明，未挂载的 Command 契约剔除并告警）；但 spec 仓库 `registry/` 仍只有示例工件 `host-descriptor.tui.example.json`（`facetApiVersions=["v1alpha1"]`），没有可供离线 `validate:manifest --host` 复验的「真实」descriptor 发布物，本扩展也尚未对运行中 dsh-tui 导出的 descriptor 实测协商。证据等级维持 `Declared` 的理由由「宿主侧不存在」修正为「尚未实测 + 工件未发布」。
+- **D-2 真实 Host Descriptor 已实测协商（2026-08-23 闭环）**：spec registry 无可离线复验的 descriptor 发布工件，但 dsh-TUI 已在运行时构建真实 Host Descriptor；本试点已于 2026-08-23 对运行中 dsh-tui 0.8.8 经 `/plugins check` 完成协商 → **`compatible`**（见证据节）。证据等级维持 `Declared` 的理由收窄为「entry 不可被 dsh 直接加载（D-1）+ 无 activation/lifecycle 接入（D-3）」，协商维度已实测。
 - **D-3 本插件侧未接入 effect ledger / lifecycle（2026-08-23 修订）**：宿主侧生命周期实体已实现——dsh-TUI 的效果台账（C-060，`~/.dsh-tui/effect-ledger.jsonl`，pluginId / activationInstance / runtimeGenerationId 三元组）与统一授权存储均已上线；偏差收窄为本扩展作为 VS Code companion 未声明 activation instance、未接入宿主台账，行为仍走 VS Code 终端与会话文件系统。
 - **D-4 与 Cordis bundle 双轨并存**：实际可运行层仍是 `package.json` 的 `dsh.bundle` + `cordis.patch.yml`；`dsh-plugin.json` 是额外试点声明，两者尚未统一。
 - **D-5 证据等级为 Declared**：试点 manifest 已通过上游 dsh-std v0.15 的 schema + 语义校验（`parseManifest` → `projectManifest` → `manifestDefinitions.validate`），并对上游仓库的示例(example)Host Descriptor（`registry/host-descriptor.tui.example.json`）协商出 **`compatible`**（无 required 缺失、无 denied permission）。2026-08-21 起该复核可经官方入口 `npm run validate:manifest` 一键复现（上游 PR #5）。但因 entry 不可被 dsh 直接加载（D-1）且真实 host 协商未发生，证据等级仍为 `Declared`，不能声称 `Tested` / `Verified`。
@@ -41,7 +41,8 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
   - `npm run test:standalone` 全量 suite 退出码 0（manifest/Host Descriptor/envelope/ledger/claim 正反 fixture 与五态协商矩阵全部符合预期）；
   - 官方入口 `npm run validate:manifest -- --manifest ./dsh-plugin.json --host registry/host-descriptor.tui.example.json` → `{"valid":true,"decision":"compatible","missingOptional":[]}`，exit 0；
   - 结论维持 **`compatible`**（结构 + 语义 + 协商全过；PR #5 将 admission 算法抽为共用核心 `admission-core.js` 后复核结论不变）。
-- 宿主侧复核（2026-08-23，headless 复刻 `/plugins check` 全链：parseManifest → projectManifest → createContractIndex(vendored registry/permissions) → validatePlugin → buildHostDescriptor → negotiate，dsh-tui 0.8.8 安装副本）：**TUI semantic validation PASS**，negotiate → **`compatible`**（host.dropped=[] / warnings=[]）；最小合规形态（单命令 `.start`）；真实终端留档待补。
+- 宿主侧复核（2026-08-23，headless 复刻 `/plugins check` 全链：parseManifest → projectManifest → createContractIndex(vendored registry/permissions) → validatePlugin → buildHostDescriptor → negotiate，dsh-tui 0.8.8 安装副本）：**TUI semantic validation PASS**，negotiate → **`compatible`**（host.dropped=[] / warnings=[]）；最小合规形态（单命令 `.start`）。
+- 真实宿主协商留档（2026-08-23，运行中 dsh-tui 0.8.8，真实终端 `/plugins check D:\...\dsh-plugin.json`）：C-070 信任横幅后输出 **「协商结果：compatible」**。headless 预测与真实宿主一致，negotiated 维度闭环。
 - 注：上游 [PR #2](https://github.com/T-Auto/dsh-ecosystem-spec/pull/2)（conformance 加载对齐）已合并，修复早期「独立检出无法运行」问题；独立检出现在用 `npm run test:standalone`（等价 `node scripts/conformance.mjs --standalone`）。
 - 已合入上游：本 Note 已随 [T-Auto/dsh-ecosystem-spec PR #3](https://github.com/T-Auto/dsh-ecosystem-spec/pull/3) 合入 `adapters/dsh-tui-vscode-v0.15.md`（生态首篇 Adapter Note；曾列于 README「生态扩展一览表」首行，该表后被上游提交 `69052fd` 移除，见「上游演变跟踪」）。
 - 现有 CI：`npm test` / `npm run test:e2e` 覆盖 VS Code 扩展行为，不覆盖 v0.15 conformance。
@@ -59,7 +60,7 @@ dsh-tui-vscode 是 dsh-TUI 的 VS Code companion 扩展。它在 dsh 生态里�
 
 ## 收敛计划
 
-1. 以 `/plugins check` 对运行中 dsh-tui 完成真实宿主协商留档（headless 复刻链已 PASS + compatible，真实终端复核待补）；
+1. ✅ 2026-08-23 完成：真实宿主 `/plugins check` 协商 `compatible`（headless 复刻链先行预测一致，均已留档）；
 2. 上游裁决 Gap 3（多命令权限语义冲突）后恢复 `resume` 命令与第二条 invoke 授权声明；
 3. 等 Cordis 或 dsh loader 支持读取 `dsh-plugin.json` 作为包身份层；
 4. 再决定 entry 是否需要改为独立的 Node/Cordis 入口；

--- a/docs/gap-reports.md
+++ b/docs/gap-reports.md
@@ -87,3 +87,61 @@ AssertionError [ERR_ASSERTION]: storage.local schemaHash drifted
 - **维持本地记录**：按 2026-08 决策仅保留本文件记录，暂不提交上游 issue / PR；
 - 后续如上游进入 Candidate 验收需要示例插件，可再评估补提。
 - **2026-08-23 时效审计更新**：子项 2（`docs/plugins.md` 未提及 v0.15）已失效——该文档现含完整「社区互操作规范（Community Consensus v0.15）」章节且宿主侧实现（校验库 / Host Descriptor 构建 / 授权存储 / 效果台账 / `/plugins`）已落地；子项 3（全 GitHub 搜 `filename:dsh-plugin.json` 为 0）已失效——现命中约 200+（含 dsh-data-agent / dsh-lark-bot / dsh-deepread 等真实插件仓及第三方市场目录）。子项 1（plugin-template 缺 manifest）本轮未复核，状态不明。「规范强制后现存社区插件全不兼容」的风险判断随之显著下调。
+
+---
+# Gap Report 3 — 多命令插件的 `commands.invoke` 授权语义在现行规则下不可满足
+
+## 现象 / Symptom
+
+对运行中的 dsh-tui 0.8.8 执行 `/plugins check <manifest>`，单条命名空间 scope 的授权报错：
+
+```
+语义校验失败：commands.invoke scope is not a declared command: com.baobaolaodie.dsh-tui-vscode
+```
+
+改为逐命令 scope（两条 `commands.invoke`，scope 分别为 `.start` / `.resume`）后，
+在**同一套 std 上**于 parse 阶段即被拒：
+
+```
+component spec.facets[0].permissions contains duplicate permission
+  "community.dsh/v1alpha1\u0000Permission\u0000commands.invoke"
+```
+
+## 根因 / Root cause
+
+三条规则合取后互相矛盾（均为实测/读源码确认）：
+
+1. **@dsh-std/manifest 0.1.0 解析层**（spec pin `614dfa1` 与 dsh-tui 0.8.8 内置副本行为一致）：社区 manifest 权限按
+   `community.dsh/v1alpha1␀Permission␀<name>` 去重——**同 name 仅允许一条，scope 不参与去重键**；
+2. **dsh-tui profile 层正向校验**（`plugin-spec/validate.js`）：每条 `commands.invoke` 的 scope 必须命中 `contributes.commands[].id`；
+3. **dsh-tui profile 层反向校验**（同文件）：每个已声明命令都必须存在 scope 恰等于该命令 id 的 `commands.invoke` 授权。
+
+⇒ 插件声明 N≥2 个命令时需要 N 条同名权限（规则 3），但规则 1 只允许 1 条；而仅声明 1 条时其 scope 只能覆盖 1 个命令（规则 2），其余命令必然违反规则 3。**不存在可过审的 manifest 形态。**
+
+## 影响 / Impact
+
+- 任何声明 ≥2 个命令的插件都无法通过 `/plugins check` 或上游 `validate:manifest`；
+- 直接阻碍上游进入 Candidate 所需的「多实现证据」——多命令插件是常态而非例外；
+- 本试点被迫收敛为单命令最小合规形态（仅 `.start`），`resume` 声明暂缓。
+
+## 复现 / Reproduction
+
+- dsh-tui 0.8.8（global 与 profile 副本一致），@dsh-std/manifest 0.1.0；
+- spec 侧：T-Auto/dsh-ecosystem-spec main `d406de4` + vendor pin `614dfa1`，`npm run validate:manifest`；
+- 宿主侧：headless 复刻 `/plugins check` 全链（parseManifest → projectManifest → createContractIndex(vendored) → validatePlugin → buildHostDescriptor → negotiate），两种形态的错误均复现；
+- 单命令最小形态：双侧同时 PASS / `compatible`。
+
+## 建议修复 / Suggested fix（二选一，需上游裁决）
+
+1. **改 std**：解析层去重键改为 `name␀scope`（lib 内已有先例键形），允许同 name 不同 scope 的多条授权；
+2. **改 dsh-tui profile 层**：放宽为「action 级授权覆盖全部已声明命令」（如支持插件命名空间前缀 scope），或取消反向覆盖要求。
+
+## 涉及仓库 / Repos
+
+- `Yan-Zero/dsh-std`（@dsh-std/manifest 解析层去重键）
+- `ccch1mneyyy/dsh-TUI`（`src/plugin-spec/validate.js` 正反向校验）
+- `T-Auto/dsh-ecosystem-spec`（vendor pin 与 conformance fixture 未覆盖多命令场景）
+
+## 状态跟踪 / Status
+
+- **维持本地记录**：按 2026-08 决策暂不提交上游 issue；本试点已按单命令最小合规形态保持双侧全绿，上游裁决后恢复 `resume` 声明。

--- a/docs/gap-reports.md
+++ b/docs/gap-reports.md
@@ -1,0 +1,88 @@
+# Gap Report 1 — dsh-ecosystem-spec Windows conformance test fails due to CRLF hash drift
+
+## 现象 / Symptom
+
+在 Windows 上克隆 `T-Auto/dsh-ecosystem-spec` 后运行 `npm test`，立即失败：
+
+```
+AssertionError [ERR_ASSERTION]: storage.local schemaHash drifted
++ actual:   sha256:e9058da348d...
+- expected: sha256:a43bd499060...
+```
+
+## 根因 / Root cause
+
+- `registry/contracts/storage.local-0.15.json` 的 `schemaHash` 是按 **LF 字节**计算的。
+- 该仓库没有 `.gitattributes` 强制 LF。
+- Windows 默认 `core.autocrlf=true` 时，Git checkout 会把文件转成 **CRLF**。
+- 因此本机文件的 SHA-256 与 registry 记录不一致。
+
+## 影响 / Impact
+
+- 规范宣称“npm test 即可验证”，但 Windows 开发者无法复现。
+- 这直接破坏了“可执行规范”的可复现性，是作者所说的“不稳定会爆规范疏漏”的具体实例。
+
+## 建议修复 / Suggested fix
+
+在仓库根目录添加 `.gitattributes`：
+
+```
+* text=auto eol=lf
+*.json text eol=lf
+*.md text eol=lf
+```
+
+并重新校对所有 registry schemaHash（确认是按 LF 字节计算）。
+
+## 涉及文件 / Files
+
+- `.gitattributes`（新增）
+- `registry/contracts/*.json`
+- `registry/registry-0.15.json`
+- `conformance/tests/run.js`（如果还需要做换行归一化兜底）
+
+## 状态跟踪 / Status
+
+- **已提交**：作为 [T-Auto/dsh-ecosystem-spec#1](https://github.com/T-Auto/dsh-ecosystem-spec/issues/1)（由 baobaolaodie 提交）。
+- **已修复并关闭**：T-Auto 于 2026-08-18 关闭（评论“已修复！”）；修复方式为新增 `.gitattributes`，对 `registry/contracts/*.json` 与 `schemas/*.json` 强制 `eol=lf`。
+- 注：`registry/registry-0.15.json`、`registry/permissions-0.1.json` 不在 `.gitattributes` 覆盖范围内，但 conformance runner 只对 `registry/contracts/*.json` 与 `schemas/*.json` 做 hash 校验，故不影响 `npm test` 复现。
+
+---
+# Gap Report 2 — Official plugin template and docs not aligned with dsh-ecosystem-spec v0.15
+
+## 现象 / Symptom
+
+- `dsh-tui-ecosystem/plugin-template` 只有 `package.json` + `cordis.patch.yml`，**没有 `dsh-plugin.json`**。
+- `dsh-TUI/docs/plugins.md` 完全没有提及 v0.15 manifest / `facets.host` / contract coordinates / Host Descriptor。
+- 整个 GitHub 搜索 `filename:dsh-plugin.json` 结果为 **0**。
+
+## 根因 / Root cause
+
+- 当前 dsh 插件生态的实际可运行格式是 **Cordis bundle**（`package.json` 的 `dsh.bundle.patch` + `cordis.patch.yml`）。
+- dsh-ecosystem-spec v0.15 定义的发现入口是 **`dsh-plugin.json`**，两者没有适配层。
+- 官方模板还在教 Cordis bundle，没跟上 spec。
+
+## 影响 / Impact
+
+- 如果规范开始强制，**现存所有社区插件都会不兼容**。
+- 开发者想“按规范写插件”也没有可靠样板可参照。
+- 会阻碍规范进入 Candidate（候选验收要求 3 个示例插件）。
+
+## 建议修复 / Suggested fix
+
+1. 在 `plugin-template` 增加 `dsh-plugin.json`，作为官方样板；
+2. 在 `docs/plugins.md` 增加“生态兼容层”章节，说明 `dsh-plugin.json` 与 `cordis.patch.yml` 的关系；
+3. 在 `dsh-ecosystem-spec/adapters/` 增加至少一篇 Adapter Note，映射 Cordis bundle → v0.15 manifest；
+4. 以 `dsh-tui-vscode` 分支 `feat/dsh-ecosystem-spec` 作为第一个真实试点参考。
+
+## 涉及仓库 / Repos
+
+- `dsh-tui-ecosystem/plugin-template`
+- `ccch1mneyyy/dsh-TUI` (`docs/plugins.md`)
+- `T-Auto/dsh-ecosystem-spec` (`adapters/`)
+- `baobaolaodie/dsh-tui-vscode`（试点参考）
+
+## 状态跟踪 / Status
+
+- **维持本地记录**：按 2026-08 决策仅保留本文件记录，暂不提交上游 issue / PR；
+- 后续如上游进入 Candidate 验收需要示例插件，可再评估补提。

--- a/docs/gap-reports.md
+++ b/docs/gap-reports.md
@@ -86,3 +86,4 @@ AssertionError [ERR_ASSERTION]: storage.local schemaHash drifted
 
 - **维持本地记录**：按 2026-08 决策仅保留本文件记录，暂不提交上游 issue / PR；
 - 后续如上游进入 Candidate 验收需要示例插件，可再评估补提。
+- **2026-08-23 时效审计更新**：子项 2（`docs/plugins.md` 未提及 v0.15）已失效——该文档现含完整「社区互操作规范（Community Consensus v0.15）」章节且宿主侧实现（校验库 / Host Descriptor 构建 / 授权存储 / 效果台账 / `/plugins`）已落地；子项 3（全 GitHub 搜 `filename:dsh-plugin.json` 为 0）已失效——现命中约 200+（含 dsh-data-agent / dsh-lark-bot / dsh-deepread 等真实插件仓及第三方市场目录）。子项 1（plugin-template 缺 manifest）本轮未复核，状态不明。「规范强制后现存社区插件全不兼容」的风险判断随之显著下调。

--- a/dsh-plugin.json
+++ b/dsh-plugin.json
@@ -21,13 +21,8 @@
   "permissions": [
     {
       "name": "commands.invoke",
-      "scope": "com.baobaolaodie.dsh-tui-vscode.start",
-      "reason": "启动 dsh-TUI 会话"
-    },
-    {
-      "name": "commands.invoke",
-      "scope": "com.baobaolaodie.dsh-tui-vscode.resume",
-      "reason": "恢复 dsh-TUI 会话"
+      "scope": "com.baobaolaodie.dsh-tui-vscode",
+      "reason": "启动/恢复 dsh-TUI 会话（覆盖 start/resume 两个已声明命令）"
     }
   ],
   "contributes": {
@@ -46,7 +41,7 @@
   "license": "MIT",
   "source": {
     "repository": "https://github.com/baobaolaodie/dsh-tui-vscode.git",
-    "revision": "main"
+    "revision": "feat/dsh-ecosystem-spec"
   },
   "compat": {
     "hosts": [

--- a/dsh-plugin.json
+++ b/dsh-plugin.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://dsh.community/schemas/dsh-plugin-0.15.json",
+  "id": "com.baobaolaodie.dsh-tui-vscode",
+  "name": "dsh-tui-vscode (VS Code companion)",
+  "version": "0.6.1",
+  "manifestVersion": "0.15",
+  "facets": {
+    "host": {
+      "entry": "out/extension.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": [
+      {
+        "apiVersion": "commands.dsh/v1alpha1",
+        "kind": "Command"
+      }
+    ]
+  },
+  "permissions": [
+    {
+      "name": "commands.invoke",
+      "scope": "com.baobaolaodie.dsh-tui-vscode.start",
+      "reason": "启动 dsh-TUI 会话"
+    },
+    {
+      "name": "commands.invoke",
+      "scope": "com.baobaolaodie.dsh-tui-vscode.resume",
+      "reason": "恢复 dsh-TUI 会话"
+    }
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "id": "com.baobaolaodie.dsh-tui-vscode.start",
+        "title": "Start new dsh-TUI session"
+      },
+      {
+        "id": "com.baobaolaodie.dsh-tui-vscode.resume",
+        "title": "Resume last dsh-TUI session"
+      }
+    ]
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/baobaolaodie/dsh-tui-vscode.git",
+    "revision": "main"
+  },
+  "compat": {
+    "hosts": [
+      "dsh-tui >=0.7.0"
+    ]
+  },
+  "overrides": [
+    {
+      "target": "cordis.patch.yml",
+      "kind": "patch",
+      "description": "Existing VS Code companion integration kept as the executable layer; this manifest is an experimental v0.15 declaration for ecosystem compatibility testing."
+    }
+  ]
+}

--- a/dsh-plugin.json
+++ b/dsh-plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://dsh.community/schemas/dsh-plugin-0.15.json",
   "id": "com.baobaolaodie.dsh-tui-vscode",
   "name": "dsh-tui-vscode (VS Code companion)",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "manifestVersion": "0.15",
   "facets": {
     "host": {

--- a/dsh-plugin.json
+++ b/dsh-plugin.json
@@ -21,8 +21,8 @@
   "permissions": [
     {
       "name": "commands.invoke",
-      "scope": "com.baobaolaodie.dsh-tui-vscode",
-      "reason": "启动/恢复 dsh-TUI 会话（覆盖 start/resume 两个已声明命令）"
+      "scope": "com.baobaolaodie.dsh-tui-vscode.start",
+      "reason": "启动新 dsh-TUI 会话；resume 因上游多命令权限语义冲突暂缓声明（见 docs/gap-reports.md Gap 3）"
     }
   ],
   "contributes": {
@@ -30,10 +30,6 @@
       {
         "id": "com.baobaolaodie.dsh-tui-vscode.start",
         "title": "Start new dsh-TUI session"
-      },
-      {
-        "id": "com.baobaolaodie.dsh-tui-vscode.resume",
-        "title": "Resume last dsh-TUI session"
       }
     ]
   },


### PR DESCRIPTION
## 摘要 / Summary

同步 dsh-ecosystem-spec 生态对齐工作的最新状态(上游 main `d406de4`,2026-08-22),含一轮完整时效审计与一次真实宿主实测。

**动机**:适配说明的证据方式被上游 PR #5 的官方 CLI 取代、D-2/D-3 表述因 dsh-TUI 宿主侧落地而过时、manifest 版本与 package.json 漂移。
**做法**:证据节升级为官方双入口实跑结果;D-2/D-3 按 2026-08-23 时效审计改写;版本对齐 0.6.3;实测发现多命令权限语义冲突(Gap 3)后收敛为单命令最小合规形态。
**影响**:无用户可见行为变更(`dsh-plugin.json` 为声明性试点文件,不参与扩展运行时);文档同步于实测事实。

## 改动范围（勾选）/ Scope of Changes (check)

- [ ] 核心逻辑（终端 / 会话）/ Core logic (terminal / session)
- [ ] 会话历史（侧边栏）/ Session history (sidebar)
- [x] 文档（README / docs / CHANGELOG / CONTRIBUTING）/ Docs
- [x] 其他 / Other: dsh-plugin.json(生态试点声明)、.gitignore(本地目录忽略)

## 验证（勾选已执行）/ Verification (check executed)

- [x] 单元测试 / Unit tests（命令 + 结果 / command + result）: `npm test` → 61/61 pass(pre-commit 与 CI 均绿)
- [x] 手动验证 / Manual verification（描述场景 / describe the scenario）: ① 上游独立检出(main `d406de4` + vendor `614dfa1`)官方入口校验;② dsh-tui 0.8.8 安装副本上 headless 复刻 `/plugins check` 全链(parseManifest→projectManifest→createContractIndex(vendored)→validatePlugin→buildHostDescriptor→negotiate);③ 真实终端 `/plugins check` 复核留档进行中
- [x] 文档改动：中英双语同步 / Doc changes: EN and ZH mirrored
- [x] 关键验证输出已粘贴至验证段下方 / Key verification output pasted below
- [ ] 如有未运行的验证项（说明原因）/ Not run if any (explain): 真实宿主协商留档待补(见收敛计划第 1 条);e2e 由 CI 覆盖

关键输出:

```
# 上游官方入口(spec main d406de4)
{"valid":true,"decision":"compatible","missingOptional":[]}   exit 0

# 宿主链(dsh-tui 0.8.8 vendored profile, 最小合规形态)
TUI semantic validation: PASS
negotiate: {"decision":"compatible"}   host.dropped=[] host.warnings=[]
```

实测发现并已记录 `docs/gap-reports.md` Gap 3:@dsh-std 解析层按 name 去重权限(scope 不参与),而 dsh-tui profile 层要求逐命令 scope 正反向覆盖——**声明 ≥2 个命令的插件在现行规则下不存在可过审形态**。本 PR 据此将 manifest 收敛为单命令最小合规形态(仅 `.start`),`resume` 待上游裁决后恢复。

## 自查（勾选）/ Self-check (check)

- [ ] 行为变化已记入 CHANGELOG(Unreleased)/ Behavior changes recorded in CHANGELOG (Unreleased)
- [x] 版本号与实现一致 / Version number matches the implementation
- [x] 无无关文件或本地伪影 / No unrelated files or local artifacts

## 基于版本 / Based on

main @ `18be00c`(0.6.3 之后无发布版本变更);上游基线 T-Auto/dsh-ecosystem-spec main `d406de4`。

## 关联（可选）/ Related (optional)

上游互动史:T-Auto/dsh-ecosystem-spec PR #3(Note 合入)、#5(官方校验入口)、#8(RFC 0009,观察中)。

## 审查注意点 / Review Notes

1. `dsh-plugin.json` 的 `$schema` 指向 `https://dsh.community/schemas/dsh-plugin-0.15.json`(上游生态约定域名);
2. Gap 3 是本次最重要的发现——建议上游优先裁决(std 去重键 vs dsh-tui 逐命令正反向校验),裁决前 manifest 保持单命令形态;
3. 提交 `c5d11fd` 将 manifest version 从 0.6.1 对齐到 package.json 的 0.6.3,后续发版需同步维护该字段。